### PR TITLE
Added new FloatAttribute alpha test for transparent objects.

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -139,6 +139,7 @@ public class Scene implements Named{
 				BlendingAttribute ba = new BlendingAttribute(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 				ba.opacity = mat.get("opacity").asFloat();
 				material.set(ba);
+				material.set(FloatAttribute.createAlphaTest(0));
 			}
 
 			materials.put(mat.name, material);


### PR DESCRIPTION
Added an alpha test float attribute for transparent materials to ensure they sort correctly. Could slow things down theoretically, so keep this in mind in the future in case we need to add an option to change it.