### PR TITLE
Create a blendmode attribute in blendMode() for materials if one doesn't exist already.

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -425,6 +425,11 @@ public class GameObject implements Named{
 
 			BlendingAttribute ba = (BlendingAttribute) mat.get(BlendingAttribute.Type);
 
+			if (ba == null){
+				ba = new BlendingAttribute();
+				mat.set(ba);
+			}
+
 			ba.sourceFunction = src;
 			ba.destFunction = dest;
 


### PR DESCRIPTION
Like the title says, it creates a blend mode attribute for materials that don't have one already in GameObject.blendMode(). Fixed bug #82.