### PR TITLE
Addresses issue (#102). Creates a new list for GameObject.end().

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -283,7 +283,7 @@ public class GameObject implements Named{
 	}
 	
 	public void end(){
-		for (GameObject g : children){
+		for (GameObject g : new ArrayList<GameObject>(children)){
 			g.end();
 		}
 		scene.remove(this);


### PR DESCRIPTION
Creates a new list before looping through a GameObject's children to end them when using the end() function. Fixes broken end()ing functionality.

PR for issue (#102).