### PR TITLE
Profiler adjustments (#76)

### DIFF
--- a/blender/bdx/gen/BdxApp.java
+++ b/blender/bdx/gen/BdxApp.java
@@ -40,19 +40,19 @@ public class BdxApp implements ApplicationListener {
 
 	@Override
 	public void render() {
-		Bdx.profiler.start();
+		Bdx.profiler.start("__graphics");
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		Bdx.profiler.stop("graphics");
+		Bdx.profiler.stop("__graphics");
 
 		Bdx.updateInput();
-		Bdx.profiler.stop("input");
+		Bdx.profiler.stop("__input");
 
 		for (Scene s : (ArrayListNamed<Scene>)Bdx.scenes.clone()){
 			s.update();
-			Bdx.profiler.start();
+			Bdx.profiler.start("__render");
 			renderScene(s);
-			Bdx.profiler.stop("render");
+			Bdx.profiler.stop("__render");
 		}
 		Bdx.profiler.update();
 	}

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -635,24 +635,24 @@ public class Scene implements Named{
 		
 		if (!paused){
 
-			Bdx.profiler.start();
+			Bdx.profiler.start("__logic");
 			runObjectLogic();			
-			Bdx.profiler.stop("logic");
+			Bdx.profiler.stop("__logic");
 			
 			updateVisuals();
-			Bdx.profiler.stop("visuals");
+			Bdx.profiler.stop("__visuals");
 			
 			updateCamera();
-			Bdx.profiler.stop("camera");
+			Bdx.profiler.stop("__camera");
 			
 			world.stepSimulation(Bdx.TICK_TIME, 0);
-			Bdx.profiler.stop("worldStep");
+			Bdx.profiler.stop("__worldStep");
 			
 			updateChildBodies();
-			Bdx.profiler.stop("children");
+			Bdx.profiler.stop("__children");
 			
 			detectCollisions();
-			Bdx.profiler.stop("collisions");
+			Bdx.profiler.stop("__collisions");
 			
 		}
 


### PR DESCRIPTION
Points to consider:
- User defined categories may not start with ```"__"```. Is there a better alternative?
- User defined categories will be added at the bottom of the list. Would it be better to have a separate linked hash map for ```userPercents```?
- Eventually, when we have an overlay scene to display the profiler, should milliseconds also be displayed? If so, I also should add a hash map ```millis```.
- Now there's a method ```percents()```, but eventually, should this be removed? Because everything would already be displayed, which would make it a bit obsolete.