### PR TITLE
Basic 2D filter support and default shaders.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -5,6 +5,7 @@ import java.util.*;
 import com.badlogic.gdx.*;
 import com.badlogic.gdx.files.*;
 
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.nilunder.bdx.inputs.*;
 import com.nilunder.bdx.audio.*;
 import com.nilunder.bdx.utils.ArrayListNamed;
@@ -80,6 +81,9 @@ public class Bdx{
 		for (int i = 0; i < 10; ++i){
 			allocatedFingers.add(new Finger(i));
 		}
+
+		ShaderProgram.pedantic = false;
+
 	}
 
 	public static void updateInput(){

--- a/src/com/nilunder/bdx/Filter.java
+++ b/src/com/nilunder/bdx/Filter.java
@@ -1,0 +1,20 @@
+package com.nilunder.bdx;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+
+/**
+ * Created by SolarLune on 3/18/2015.
+ */
+public class Filter extends ShaderProgram {
+	public Filter(String vertexShader, String fragmentShader) {
+		super(vertexShader, fragmentShader);
+
+		if (!isCompiled()) {
+			throw new RuntimeException("Shader compilation error: " + getLog());
+		}
+	}
+	public Filter(FileHandle vertexShader, FileHandle fragmentShader) {
+		this(vertexShader.readString(), fragmentShader.readString());
+	}
+}

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.attributes.*;
 import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
@@ -69,7 +70,7 @@ public class Scene implements Named{
 	private Instantiator instantiator;
 	
 	private HashMap<String, GameObject> templates;
-	
+	public Filter filter;
 	
 	public Scene(String name){
 		this(Gdx.files.internal("bdx/scenes/" + name + ".bdx"), instantiators.get(name));
@@ -661,4 +662,5 @@ public class Scene implements Named{
 		}
 
 	}
+
 }

--- a/src/com/nilunder/bdx/shaders/defaultFilter.frag
+++ b/src/com/nilunder/bdx/shaders/defaultFilter.frag
@@ -1,0 +1,17 @@
+#pragma optionNV(strict on)
+
+#ifdef GL_ES
+    precision mediump float;
+#endif
+
+varying vec4 v_color;
+varying vec2 v_texCoords;
+uniform sampler2D u_texture;
+uniform mat4 u_projTrans;
+
+void main() {
+
+    vec4 color = texture2D(u_texture, v_texCoords);
+    gl_FragColor = color;
+
+}

--- a/src/com/nilunder/bdx/shaders/defaultFilter.vert
+++ b/src/com/nilunder/bdx/shaders/defaultFilter.vert
@@ -1,0 +1,18 @@
+#pragma optionNV(strict on)
+
+attribute vec4 a_position;
+attribute vec4 a_color;
+attribute vec2 a_texCoord0;
+
+uniform mat4 u_projTrans;
+
+varying vec4 v_color;
+varying vec2 v_texCoords;
+
+void main() {
+
+    v_color = a_color;
+    v_texCoords = a_texCoord0;
+    gl_Position = u_projTrans * a_position;
+
+}


### PR DESCRIPTION
Adds basic 2D filter (shader) support (only one filter for each Scene at the moment) to Bdx. The filter application system works similarly to the BGE's - a shader applied to one Scene is also applied to the underlying scenes.

Bdx.useFramebuffers variable added to help optimize things if you're not using filters. When not on, framebuffers aren't used and filters aren't applied. Bdx.useFramebuffers defaults to off and automatically gets turned on if you add a compiling filter to a scene, and turned off if a shader doesn't compile (so everything still renders correctly even without filters).

Also added default vertex and fragment 2D filters to assist in making customized versions (making it easy to copy and expound from to make the shader you want).

To-do features:

* Multiple filters per scene via a filter stack
* Custom Filter class to make setting filters in that stack easy
* Framebuffer downsampling
* Add depth texture uniform
* Add time uniform

EDIT: Oh, I forgot to open an issue for this here, sorry. It's in reference to [this](http://www.reddit.com/r/bdx/comments/2zdkpu/about_postprocessing/) thread over on /r/bdx.