### PR TITLE
(#207) - Compound physics support.

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -413,7 +413,8 @@ def srl_objects(objects):
                 "restitution": obj.active_material.physics.elasticity if obj.active_material else 0,
                 "ghost": obj.game.use_ghost,
                 "group": sum([2**i for i, v in enumerate(obj.game.collision_group) if v]),
-                "mask": sum([2**i for i, v in enumerate(obj.game.collision_mask) if v])
+                "mask": sum([2**i for i, v in enumerate(obj.game.collision_mask) if v]),
+                "compound": obj.game.use_collision_compound
             }
         }
 

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -18,6 +18,7 @@ import com.bulletphysics.collision.narrowphase.PersistentManifold;
 import com.bulletphysics.collision.narrowphase.ManifoldPoint;
 import com.bulletphysics.collision.dispatch.CollisionFlags;
 import com.bulletphysics.collision.shapes.CollisionShape;
+import com.bulletphysics.collision.shapes.CompoundShape;
 import com.bulletphysics.dynamics.RigidBody;
 import com.bulletphysics.linearmath.MatrixUtil;
 import com.bulletphysics.linearmath.Transform;
@@ -80,6 +81,10 @@ public class GameObject implements Named{
 	public void parent(GameObject p){
 		if (parent != null){
 			parent.children.remove(this);
+
+			if (parent.compoundShape() != null)
+				parent.compoundShape().removeChildShape(body.getCollisionShape());
+
 		}
 		
 		parent = p;
@@ -91,11 +96,20 @@ public class GameObject implements Named{
 			updateLocalTransform();
 			updateLocalScale();
 
+			if (parent.compoundShape() != null)
+				parent.compoundShape().addChildShape(new Transform(localTransform), body.getCollisionShape());
+
 			dynamic(false);
 		}else{
 			dynamic(true);
 		}
 		
+	}
+
+	private CompoundShape compoundShape(){
+		if (body.getCollisionShape() instanceof CompoundShape)
+			return (CompoundShape) body.getCollisionShape();
+		return null;
 	}
 	
 	public Vector3f position(){


### PR DESCRIPTION
Adds support for compound physics using childrens' collision shapes if compound is activated for the parent in Blender.
TODO at some point: Add function / capability to shift center of mass on parent.