### PR TITLE
(#214) Support for additional built-in Filter uniforms.

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -20,11 +20,9 @@ import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.attributes.*;
 import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
-import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
-
 import com.bulletphysics.collision.broadphase.BroadphaseInterface;
 import com.bulletphysics.collision.broadphase.DbvtBroadphase;
 import com.bulletphysics.collision.dispatch.CollisionDispatcher;
@@ -35,7 +33,6 @@ import com.bulletphysics.dynamics.DiscreteDynamicsWorld;
 import com.bulletphysics.dynamics.RigidBody;
 import com.bulletphysics.dynamics.constraintsolver.SequentialImpulseConstraintSolver;
 import com.bulletphysics.linearmath.Transform;
-
 import com.nilunder.bdx.utils.*;
 import com.nilunder.bdx.inputs.*;
 import com.nilunder.bdx.components.*;
@@ -71,6 +68,7 @@ public class Scene implements Named{
 	
 	private HashMap<String, GameObject> templates;
 	public ArrayList<Filter> filters;
+	public RenderBuffer lastFrameBuffer;
 	
 	public Scene(String name){
 		this(Gdx.files.internal("bdx/scenes/" + name + ".bdx"), instantiators.get(name));
@@ -101,6 +99,8 @@ public class Scene implements Named{
 		requestedRestart = false;
 		paused = false;
 
+		lastFrameBuffer = new RenderBuffer(null);
+		
 		filters = new ArrayList<Filter>();
 		defaultMaterial = new Material();
 		defaultModel = new ModelBuilder().createBox(1.0f, 1.0f, 1.0f, defaultMaterial, Usage.Position | Usage.Normal | Usage.TextureCoordinates);
@@ -237,6 +237,10 @@ public class Scene implements Named{
 
 	}
 
+	public void dispose(){
+		lastFrameBuffer.dispose();
+	}
+	
 	private void hookParentChild(){
 		for (GameObject g : templates.values()){
 			String parentName = g.json.get("parent").asString();

--- a/src/com/nilunder/bdx/utils/RenderBuffer.java
+++ b/src/com/nilunder/bdx/utils/RenderBuffer.java
@@ -1,0 +1,56 @@
+package com.nilunder.bdx.utils;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.nilunder.bdx.Filter;
+
+public class RenderBuffer extends FrameBuffer{
+		
+	private SpriteBatch batch;
+		
+	public RenderBuffer(SpriteBatch batch) {
+		
+		super(Pixmap.Format.RGBA8888, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
+		getColorBufferTexture().setFilter(Texture.TextureFilter.Nearest, Texture.TextureFilter.Nearest);
+		this.batch = batch;
+				
+	}	
+	
+	public void drawTo(RenderBuffer dest,Filter filter){
+		
+		TextureRegion region = new TextureRegion(this.getColorBufferTexture());
+		region.flip(false, true);
+		
+		if (dest != null)
+			dest.begin();
+				
+		batch.begin();
+		batch.setShader(filter);
+		batch.draw(region, 0, 0);
+		batch.end();
+		
+		if (dest != null)
+			dest.end();
+		
+	}
+	
+	public void drawTo(RenderBuffer dest){
+		
+		drawTo(dest, null);
+		
+	}
+	
+	public void clear(){
+		
+		begin();
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		end();
+		
+	}
+
+}


### PR DESCRIPTION
"time" - A float that increases by 1 per second.
"lastFrame" - A sampler2D (texture) that is the complete, last rendered frame for the scene the filter runs in.

___

Changes:

- A new Buffer class has been created to sufficiently house and handle the frequent buffer updates the last frame uniform necessitates. It allows for drawing to another buffer or the screen, if null is passed. This could be expanded to work with FrameBuffers as well, rather than just BDX Buffers.

- Bdx has been altered to use multiple frame buffers (one for the scene, one for the final output, and a temporary one for shuffling) to properly handle drawing to a framebuffer with a shader. This was done as it seems OpenGL doesn't like writing to and reading from the same framebuffer at the same time.

- Each Scene now has a lastFrameBuffer Buffer that houses the texture from the last frame for that scene.