### PR TITLE
(#235) - Basic lighting support.

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -427,6 +427,12 @@ def srl_objects(objects):
         elif obj.type == "FONT":
             d["font"] = obj.data.font.name
             d["text"] = obj.data.body
+            
+        elif obj.type == "LAMP":
+            d['lamp'] = {"type": obj.data.type, 
+                          "energy": obj.data.energy,
+                          "color": list([obj.data.color[0], obj.data.color[1], obj.data.color[2], 1]),
+                          "distance": obj.data.distance}
 
     return name_object
 
@@ -445,7 +451,8 @@ def srl_materials(materials):
                 {"texture": texture_name(m),
                  "alpha_blend": "ALPHA" if m.use_transparency else "OPAQUE",
                  "color": list(m.diffuse_color),
-                 "opacity": m.alpha}
+                 "opacity": m.alpha,
+                 "shadeless": m.use_shadeless}
             for m in materials}
 
 
@@ -619,10 +626,17 @@ def export(context, filepath, scene_name, exprun):
     ts = texts(objects)
     fonts = used_fonts(ts)
 
+    if scene.world != None:
+        ambient_color = list(scene.world.ambient_color)
+        ambient_color.append(1)
+    else:
+        ambient_color = [0,0,0,1]
+
     bdx = {
         "name": scene.name,
         "gravity": scene.game_settings.physics_gravity,
         "physviz": scene.game_settings.show_physics_visualization,
+        "ambientColor": ambient_color,
         "models": srl_models(used_meshes(objects)),
         "objects": srl_objects(objects),
         "materials": srl_materials(used_materials(objects)),

--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -148,7 +148,7 @@ public class Bdx{
 			modelBatch.begin(scene.cam);
 			for (GameObject g : scene.objects){
 				if (g.visible()){
-					modelBatch.render(g.modelInstance);
+					modelBatch.render(g.modelInstance, scene.environment);
 				}
 			}
 			modelBatch.end();

--- a/src/com/nilunder/bdx/Instantiator.java
+++ b/src/com/nilunder/bdx/Instantiator.java
@@ -12,6 +12,9 @@ public class Instantiator {
 		if (type.equals("FONT")){
 			return new Text();
 		}
+		if (type.equals("LAMP")){
+			return new Light();
+		}
 		return new GameObject();
 	}
 	

--- a/src/com/nilunder/bdx/Light.java
+++ b/src/com/nilunder/bdx/Light.java
@@ -1,0 +1,68 @@
+package com.nilunder.bdx;
+
+import javax.vecmath.Matrix4f;
+import javax.vecmath.Vector3f;
+import javax.vecmath.Vector4f;
+
+import com.badlogic.gdx.graphics.g3d.environment.BaseLight;
+import com.badlogic.gdx.graphics.g3d.environment.DirectionalLight;
+import com.badlogic.gdx.graphics.g3d.environment.PointLight;
+
+public class Light extends GameObject {
+
+	public String type;
+	private float energy;
+	private Vector4f color;
+	public BaseLight lightData;
+	
+	public void makeLightData(){
+		
+		if (type.equals("POINT"))
+			lightData = new PointLight();
+		else if (type.equals("SUN"))
+			lightData = new DirectionalLight();	
+		
+		updateLight();
+	}
+			
+	public void color(float r, float g, float b, float a){
+		this.color = new Vector4f(r,g,b,a);
+		updateLight();
+	}
+	
+	public Vector4f color(){
+		return color;
+	}
+		
+	public void energy(float energy) {
+		this.energy = energy;
+		updateLight();
+	}
+	
+	public float energy(){
+		return energy;
+	}
+	
+	public void updateLight(){
+		if (lightData != null) {
+			if (type.equals("POINT")) {
+				PointLight p = (PointLight)lightData;
+				p.set(color.x, color.y, color.z, position().x, position().y, position().z, energy);
+			}
+			else if (type.equals("SUN")) {
+				DirectionalLight d = (DirectionalLight)lightData;
+				Vector3f dir = axis(2).negated();
+				d.set(color.x, color.y, color.z, dir.x, dir.y, dir.z);
+			}
+		}
+	}
+	
+	@Override
+	public void transform(Matrix4f mat, boolean updateLocal) {
+				
+		super.transform(mat, updateLocal);
+		
+		updateLight();
+	}
+	
+}


### PR DESCRIPTION
Support for point, directional, and ambient lights. Energy works pretty much correctly for point lights; it doesn't do anything for directional, though.

Ambient lighting can be changed through the scene's ambientLight() function, or by setting the scene's ambient color in the world panel.

Objects can be drawn as shadeless by enabling it in the material panel in Blender.

Note that I'm using Vector4f()s for colors to be consistent in setting colors, even though lights don't use the alpha components. Also, the Light() class's color() function has to take Vector4fs to overload the GameObject color() function correctly.