### PR TITLE
(#279) replaceModel (and angularVelocity)

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -607,6 +607,47 @@ public class GameObject implements Named{
 		modelInstance = mi;
 	}
 
+	public void replaceModel(String modelName, boolean updateVisual, boolean updatePhysics){
+		if (modelName.equals(modelInstance.model.meshParts.get(0).id))
+			return;
+		Model model = null;
+		for (Scene sce : Bdx.scenes){
+			if (sce.models.containsKey(modelName)){
+				model = sce.models.get(modelName);
+				break;
+			}
+		}
+		if (model == null) throw new RuntimeException("No model found with name: '" + modelName + "'");
+		Matrix4 trans = modelInstance.transform;
+		if (updateVisual){
+			ModelInstance mi = new ModelInstance(model);
+			mi.transform.set(trans);
+			modelInstance = mi;
+		}
+		if (updatePhysics && body.isInWorld()){
+			Vector3f localInertia = new Vector3f();
+			Vector3f vel = velocity();
+			Vector3f angVel = angularVelocity();
+			scene.world.removeRigidBody(body);
+			body.destroy();
+			JsonValue physics = json.get("physics");
+			body = Bullet.makeBody(model.meshes.first(), trans.getValues(), physics);
+			body.setUserPointer(this);
+			body.setMassProps(physics.get("mass").asFloat(), localInertia);
+			body.updateInertiaTensor();
+			if (dynamic()){
+				velocity(vel);
+				angularVelocity(angVel);
+			}
+			scene.world.addRigidBody(body);
+			scene.world.updateSingleAabb(body);
+		}
+	}
+
+	public void replaceModel(String modelName){
+		replaceModel(modelName, true, false);
+	}
+
 	public String toString(){
 
 		return name + " <" + getClass().getName() + "> @" + Integer.toHexString(hashCode());

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -309,6 +309,12 @@ public class GameObject implements Named{
 		angularVelocity(v);
 	}
 	
+	public Vector3f angularVelocity(){
+		Vector3f v = new Vector3f();
+		body.getAngularVelocity(v);
+		return v;
+	}
+	
 	public boolean touching(){
 		return !touchingObjects.isEmpty();
 	}

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -53,7 +53,7 @@ public class Scene implements Named{
 
 	private FileHandle scene;
 
-	private HashMap<String,Model> models;
+	public HashMap<String,Model> models;
 	private HashMap<String,Texture> textures;
 	private HashMap<String,Material> materials;
 	public Material defaultMaterial;


### PR DESCRIPTION
I thought it was cleaner to first add a ```angularVelocity()``` method. In order to maintain physics velocities it was required to get both linear and angular velocity first, before destroying the body.

I was not very sure about ```body.updateInertiaTensor()```, so if you could let me know if this line could be removed or not, that would be nice.