### PR TITLE
(#283) Mouse and Pointer normalizedPosition fix

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -28,6 +28,9 @@ public class Bdx{
 		public Vector2f size(){
 			return new Vector2f(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		}
+		public Vector2f center(){
+			return new Vector2f(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2);
+		}
 		public void fullscreen(boolean full){
 			Graphics.DisplayMode dm = Gdx.graphics.getDesktopDisplayMode();
 			Gdx.graphics.setDisplayMode(dm.width, dm.height, full);

--- a/src/com/nilunder/bdx/inputs/Mouse.java
+++ b/src/com/nilunder/bdx/inputs/Mouse.java
@@ -74,7 +74,8 @@ public class Mouse extends Finger{
 	}
 
 	public void positionNormalized(float x, float y){
-		position((int)(x * Gdx.graphics.getWidth()), (int)(y * Gdx.graphics.getHeight()));
+		Vector2f c = Bdx.display.center();
+		position((int)(x * c.x * 2), (int)((1 - y) * c.y * 2));
 	}
 
 	public void positionNormalized(Vector2f vec){

--- a/src/com/nilunder/bdx/inputs/Pointer.java
+++ b/src/com/nilunder/bdx/inputs/Pointer.java
@@ -21,8 +21,9 @@ abstract class Pointer {
 	}
 
 	public Vector2f positionNormalized(){
-		float x = (float)Gdx.input.getX(id) / Gdx.graphics.getWidth();
-		float y = (float)Gdx.input.getY(id) / Gdx.graphics.getHeight();
+		Vector2f c = Bdx.display.center();
+		float x = (float)Gdx.input.getX(id) / (c.x * 2);
+		float y = 1 - (float)Gdx.input.getY(id) / (c.y * 2);
 		return new Vector2f(x, y);
 	}
 


### PR DESCRIPTION
With odd screen resolution it will round down to an even resolution. Added Bdx.display.center() for this.

For mouselook for example:
```java
        float x = 0.5f - Bdx.mouse.positionNormalized().x;
        rotate(0, 0, x * turnSpeed);
        Bdx.mouse.positionNormalized(0.5f, 0.5f);
```