### PR TITLE
(#297) BugFix: Blender Collision Margin support

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -410,6 +410,7 @@ def srl_objects(objects):
             "physics": {
                 "body_type": obj.game.physics_type,
                 "bounds_type": bounds_type(obj),
+                "margin": obj.game.collision_margin,
                 "mass": 0 if static(obj) else obj.game.mass,
                 "friction": obj.active_material.physics.friction if obj.active_material else 0.5,
                 "restitution": obj.active_material.physics.elasticity if obj.active_material else 0,

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -641,9 +641,10 @@ public class GameObject implements Named{
 		}
 		if (updatePhysics && body.isInWorld()){
 			String boundsType = json.get("physics").get("bounds_type").asString();
+			float margin = json.get("physics").get("margin").asFloat();
 			boolean compound = json.get("physics").get("compound").asBoolean();
 			scene.world.removeRigidBody(body);
-			body.setCollisionShape(Bullet.makeShape(model.meshes.first(), boundsType, compound));
+			body.setCollisionShape(Bullet.makeShape(model.meshes.first(), boundsType, margin, compound));
 			mass(mass());
 			body.updateInertiaTensor();
 			scene.world.addRigidBody(body);

--- a/src/com/nilunder/bdx/utils/Bullet.java
+++ b/src/com/nilunder/bdx/utils/Bullet.java
@@ -98,7 +98,7 @@ public static class DebugDrawer extends IDebugDraw{
 		return m;
 	}
 
-	public static CollisionShape makeShape(Mesh mesh, String bounds, boolean compound){
+	public static CollisionShape makeShape(Mesh mesh, String bounds, float margin, boolean compound){
 
 		CollisionShape shape;
 	
@@ -130,6 +130,7 @@ public static class DebugDrawer extends IDebugDraw{
 			Vector3f dim = new Vector3f(d.x, d.y, d.z);
 			shape = new BoxShape(dim);
 		}
+		shape.setMargin(margin);
 
 		if (compound) {
 			CompoundShape compShape = new CompoundShape();
@@ -143,9 +144,7 @@ public static class DebugDrawer extends IDebugDraw{
 	}
 	
 	public static RigidBody makeBody(Mesh mesh, float[] glTransform, JsonValue physics){
-		String boundsType = physics.get("bounds_type").asString();
-		
-		CollisionShape shape = makeShape(mesh, boundsType, physics.get("compound").asBoolean());
+		CollisionShape shape = makeShape(mesh, physics.get("bounds_type").asString(), physics.get("margin").asFloat(), physics.get("compound").asBoolean());
 		
 		float mass = physics.get("mass").asFloat();
 		String bodyType = physics.get("body_type").asString();
@@ -193,7 +192,7 @@ public static class DebugDrawer extends IDebugDraw{
 		CollisionShape shape;
 
 		if (gobj.modelInstance != null){
-			shape = makeShape(gobj.modelInstance.model.meshes.first(), physics.get("bounds_type").asString(), physics.get("compound").asBoolean());
+			shape = makeShape(gobj.modelInstance.model.meshes.first(), physics.get("bounds_type").asString(), physics.get("margin").asFloat(), physics.get("compound").asBoolean());
 		}else{
 			shape = new BoxShape(new Vector3f(0.25f, 0.25f, 0.25f));
 		}


### PR DESCRIPTION
- Previously for collision shapes of all bounding box types the collision margin was set to 0.04 by default. For this reason Dynamic Convex Hull gave different results in comparison with Dynamic Box for example, because Box doesn't actually get larger.

- With support added for the Blender Collision Margin we're able to decrease or increase the collision shape margin if wanted.

- Setting the Margin always has effect, even though at first sight Static & Dynamic Box or Static Convex Hull seem unaffected. As Blender states in the pop-up description: "Small amount required for stability".

- For every object in Blender the Collision Margin is set to 0.04 by default too. So this addition should have no effect on the user experience.