### PR TITLE
(#328) Support for Blender Mesh Origin

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -122,6 +122,18 @@ def srl_models(meshes):
 
     return name_model
 
+def srl_origins(objects):
+    name_origin = {}
+    
+    for o in objects:
+        if o.type == "MESH":
+            mesh_name = o.data.name
+            if mesh_name not in name_origin:
+                origin = sum([mt.Vector(fv) for fv in o.bound_box], mt.Vector()) / len(o.bound_box)
+                name_origin[mesh_name] = list(origin)
+    
+    return name_origin
+
 def char_uvs(char, angel_code):
     """
     Return a list of uv coordinates (for a quad)
@@ -643,6 +655,7 @@ def export(context, filepath, scene_name, exprun):
         "framerateProfile": scene.game_settings.show_framerate_profile,
         "ambientColor": ambient_color,
         "models": srl_models(used_meshes(objects)),
+        "origins": srl_origins(objects),
         "objects": srl_objects(objects),
         "materials": srl_materials(used_materials(objects)),
         "cameras": camera_names(scene),

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -213,9 +213,11 @@ public class Scene implements Named{
 				g.visibleNoChildren(false);
 				g.modelInstance = new ModelInstance(defaultModel);
 			}
+			Mesh mesh = g.modelInstance.model.meshes.first();
 			float[] trans = gobj.get("transform").asFloatArray();
-			
-			g.body = Bullet.makeBody(g.modelInstance.model.meshes.first(), trans, gobj.get("physics"));
+			JsonValue origin = json.get("origins").get(modelName);
+			g.origin = origin == null ? new Vector3f() : new Vector3f(origin.asFloatArray());
+			g.body = Bullet.makeBody(mesh, trans, g.origin, gobj.get("physics"));
 			g.currBodyType = gobj.get("physics").get("body_type").asString();
 			g.body.setUserPointer(g);
 			
@@ -309,6 +311,7 @@ public class Scene implements Named{
 		
 		g.body = Bullet.cloneBody(gobj.body);
 		g.currBodyType = gobj.currBodyType;
+		g.origin = gobj.origin;
 		g.body.setUserPointer(g);
 		g.scale(gobj.scale());
 		

--- a/src/com/nilunder/bdx/utils/Bullet.java
+++ b/src/com/nilunder/bdx/utils/Bullet.java
@@ -143,8 +143,9 @@ public static class DebugDrawer extends IDebugDraw{
 
 	}
 	
-	public static RigidBody makeBody(Mesh mesh, float[] glTransform, JsonValue physics){
-		CollisionShape shape = makeShape(mesh, physics.get("bounds_type").asString(), physics.get("margin").asFloat(), physics.get("compound").asBoolean());
+	public static RigidBody makeBody(Mesh mesh, float[] glTransform, Vector3f origin, JsonValue physics){
+		String boundsType = physics.get("bounds_type").asString();
+		CollisionShape shape = makeShape(mesh, boundsType, physics.get("margin").asFloat(), physics.get("compound").asBoolean());
 		
 		float mass = physics.get("mass").asFloat();
 		String bodyType = physics.get("body_type").asString();
@@ -154,7 +155,17 @@ public static class DebugDrawer extends IDebugDraw{
 		
 		Transform startTransform = new Transform();
 		startTransform.setFromOpenGLMatrix(glTransform);
-		MotionState motionState = new DefaultMotionState(startTransform);
+		MotionState motionState;
+		if (boundsType.equals("CONVEX_HULL")){
+			Transform centerOfMassOffset = new Transform();
+			Matrix4f originMatrix = new Matrix4f();
+			originMatrix.set(origin);
+			centerOfMassOffset.set(originMatrix);
+			startTransform.mul(centerOfMassOffset);
+			motionState = new DefaultMotionState(startTransform, centerOfMassOffset);
+		}else{
+			motionState = new DefaultMotionState(startTransform);
+		}
 		
 		RigidBodyConstructionInfo ci = new RigidBodyConstructionInfo(mass, motionState, shape, inertia);
 		


### PR DESCRIPTION
- only for Convex Hull
- all objects have the 'origin' attribute, which represents the offset vector from the bounding box center

This also fixes the ```insideFrustum()``` issue described [here](https://github.com/GoranM/bdx/issues/321#issuecomment-104385141) by @moshme. This issue was not limited to objects with no collision.

Edit: updated: check in ```insideFrustum()``` to prevent calculation when ```origin``` is an empty vector.
Edit: rebased.
Edit: forgot to update the ```centerOfMassTransform``` in ```replaceModel()```. This will be updated soon. Sorry about that.