### PR TITLE
(#343) Compound parent bugs & parent(GameObject g, boolean compound)

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -658,6 +658,12 @@ public class GameObject implements Named{
 		}
 		
 		if (updatePhysics){
+			GameObject compParent = parent != null && parent.body.getCollisionShape().isCompound() ? parent : null;
+			boolean isCompChild = compParent != null && !(currBodyType.equals("NO_COLLISION") || currBodyType.equals("SENSOR"));
+			if (isCompChild){
+				parent(null);
+			}
+			
 			Matrix4f transform = transform();
 			Vector3f scale = scale();
 			String boundsType = json.get("physics").get("bounds_type").asString();
@@ -681,10 +687,14 @@ public class GameObject implements Named{
 
 			if (body.isInWorld()){
 				scene.world.updateSingleAabb(body);
-			}else{ // update Aabb hack for NO_COLLISION
+			}else{ // update Aabb hack for when not in world
 				scene.world.addRigidBody(body);
 				scene.world.updateSingleAabb(body);
 				scene.world.removeRigidBody(body);
+			}
+
+			if (isCompChild){
+				parent(compParent);
 			}
 		}
 	}

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -81,16 +81,22 @@ public class GameObject implements Named{
 	}
 	
 	public void parent(GameObject p){
+		parent(p, true);
+	}
+
+	public void parent(GameObject p, boolean compound){
 		CompoundShape compShapeOld = null;
 		
 		if (parent != null){
 			parent.children.remove(this);
 
-			compShapeOld = parent.compoundShape();
-			if (compShapeOld != null){
-				scene.world.removeRigidBody(parent.body);
-				compShapeOld.removeChildShape(body.getCollisionShape());
-				scene.world.addRigidBody(parent.body);
+			if (compound){
+				compShapeOld = parent.compoundShape();
+				if (compShapeOld != null){
+					scene.world.removeRigidBody(parent.body);
+					compShapeOld.removeChildShape(body.getCollisionShape());
+					scene.world.addRigidBody(parent.body);
+				}
 			}
 		}
 		
@@ -103,15 +109,20 @@ public class GameObject implements Named{
 			updateLocalTransform();
 			updateLocalScale();
 
-			if (parent.compoundShape() != null){
-				scene.world.removeRigidBody(body);
-				parent.compoundShape().addChildShape(new Transform(localTransform), body.getCollisionShape());
+			if (compound){
+				CompoundShape compShape = parent.compoundShape();
+				if (compShape != null){
+					scene.world.removeRigidBody(body);
+					compShape.addChildShape(new Transform(localTransform), body.getCollisionShape());
+				}
 			}
 
 			dynamics(false);
+			
 		}else if (currBodyType.equals("STATIC") || currBodyType.equals("SENSOR")){
-			if (compShapeOld != null)
+			if (compound && compShapeOld != null)
 				scene.world.addRigidBody(body);
+			
 		}else{
 			dynamics(true);
 		}

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -81,12 +81,15 @@ public class GameObject implements Named{
 	}
 	
 	public void parent(GameObject p){
+		CompoundShape compShapeOld = null;
+		
 		if (parent != null){
 			parent.children.remove(this);
 
-			if (parent.compoundShape() != null){
+			compShapeOld = parent.compoundShape();
+			if (compShapeOld != null){
 				scene.world.removeRigidBody(parent.body);
-				parent.compoundShape().removeChildShape(body.getCollisionShape());
+				compShapeOld.removeChildShape(body.getCollisionShape());
 				scene.world.addRigidBody(parent.body);
 			}
 		}
@@ -100,14 +103,18 @@ public class GameObject implements Named{
 			updateLocalTransform();
 			updateLocalScale();
 
-			if (parent.compoundShape() != null)
+			if (parent.compoundShape() != null){
+				scene.world.removeRigidBody(body);
 				parent.compoundShape().addChildShape(new Transform(localTransform), body.getCollisionShape());
+			}
 
 			dynamics(false);
+		}else if (currBodyType.equals("STATIC") || currBodyType.equals("SENSOR")){
+			if (compShapeOld != null)
+				scene.world.addRigidBody(body);
 		}else{
 			dynamics(true);
 		}
-		
 	}
 
 	private CompoundShape compoundShape(){

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -84,9 +84,11 @@ public class GameObject implements Named{
 		if (parent != null){
 			parent.children.remove(this);
 
-			if (parent.compoundShape() != null)
+			if (parent.compoundShape() != null){
+				scene.world.removeRigidBody(parent.body);
 				parent.compoundShape().removeChildShape(body.getCollisionShape());
-
+				scene.world.addRigidBody(parent.body);
+			}
 		}
 		
 		parent = p;

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -236,9 +236,9 @@ public class Scene implements Named{
 			
 		}
 		
-		hookParentChild();
-
 		addInstances();
+
+		hookParentChild();
 		
 		cameras = new ArrayList<Camera>();
 		String[] cameraNames = json.get("cameras").asStringArray();
@@ -274,7 +274,13 @@ public class Scene implements Named{
 				g.parent(templates.get(parentName));
 			}
 		}
-
+		
+		for (GameObject g : objects){
+			String parentName = g.json.get("parent").asString();
+			if (parentName != null){
+				g.parent(objects.get(parentName));
+			}
+		}
 	}
 
 	private void addInstances(){
@@ -290,9 +296,9 @@ public class Scene implements Named{
 
 		for (GameObject gobj : temps){
 			boolean onActiveLayer = gobj.json.get("active").asBoolean();
-			if (onActiveLayer && gobj.parent() == null){
+			if (onActiveLayer){
 				GameObject g = clone(gobj);
-				addToWorld(g);
+				addToWorldNoChildren(g);
 			}
 		}
 		objects.addAll(toBeAdded);
@@ -387,14 +393,17 @@ public class Scene implements Named{
 
 
 	private void addToWorld(GameObject gobj){
+		addToWorldNoChildren(gobj);
+		for (GameObject g : gobj.children){
+			addToWorld(g);
+		}
+	}
+
+	private void addToWorldNoChildren(GameObject gobj){
 		if (!gobj.currBodyType.equals("NO_COLLISION"))
 			world.addRigidBody(gobj.body, gobj.json.get("physics").get("group").asShort(), gobj.json.get("physics").get("mask").asShort());
 		
 		toBeAdded.add(gobj);
-
-		for (GameObject g : gobj.children){
-			addToWorld(g);
-		}
 	}
 	
 	public GameObject add(GameObject gobj){		

--- a/src/com/nilunder/bdx/utils/Bullet.java
+++ b/src/com/nilunder/bdx/utils/Bullet.java
@@ -134,6 +134,7 @@ public static class DebugDrawer extends IDebugDraw{
 
 		if (compound) {
 			CompoundShape compShape = new CompoundShape();
+			compShape.setMargin(0);
 			Transform trans = new Transform();
 			trans.setIdentity();
 			compShape.addChildShape(trans, shape);


### PR DESCRIPTION
**Fix: Compound Parent(null) crash -> remove/add the parent body**

- Bug: crash when unparenting a compound parent.

**Fix: excessive Compound margin -> set to zero**

- Bug: The total collision margin of a compound object (and its children) turns out to be higher as the margin in the Blender Collision tab. It's the total of two margins. The first is the margin of the compound object itself, the second is the margin of the children. If not set, the margin value will be 0.04, so it's necessary to set the margin of the compound object to zero.

**Fix: Compound child collision detection -> remove body**

- When a collision object is parented to a compound object, the shape of that object is added to the compound shape of the parent, leaving it obsolete. This causes collision interference when the child is not ghost and redundant physics calculation. Solution is to remove their bodies from the world when compound parenting.
- At initialization the children are hooked to their parents before they are added to the world for the first time, initializing collision groups and masks also. A private addToWorldNoChildren() enables hookParentChild() to happen after this. This changes nothing else. Initialization of collision groups and masks would get complicated if not doing this while adding to the world, so this seems to be the best solution.

**Fix: replaceModel broken with Compound child -> unparent**

- Bug: replaceModel didn't support physics update if compound parented.