### PR TITLE
Fix: ensure parent(null) will not add bodies if already null

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -99,6 +99,9 @@ public class GameObject implements Named{
 					scene.world.addRigidBody(parent.body);
 				}
 			}
+			
+		}else if (p == null){
+			return;
 		}
 		
 		parent = p;


### PR DESCRIPTION
In some cases (like in the code for ```endNoChildren()```) we would like to call ```parent(null)``` to a list of objects, while some of those may already be without a parent. In such case, calling would add the body again, which is not what we want.