### PR TITLE
Fix: Bdx.end() -> exit properly so AL can unload

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -292,7 +292,7 @@ public class Bdx{
 	}
 	
 	public static void end(){
-		System.exit(0);
+		Gdx.app.exit();
 	}
 	
 	public static void resize(int width, int height) {


### PR DESCRIPTION
http://stackoverflow.com/questions/16161714/what-does-al-lib-alc-cleanup-1-device-not-closed-mean