### PR TITLE
Several shader improvements (#460).

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -256,6 +256,7 @@ def srl_materials_text(texts):
                 "color": list(m.diffuse_color) if m else [1, 1, 1],
                 "opacity": m.alpha if m else 1,
                 "shadeless": m.use_shadeless if m else True,
+                "emit": m.emit if m else 0.0,
                 "backface_culling": m.game_settings.use_backface_culling if m else True}
 
         name_gmat["__FNT_"+mat_name(m)+t.font.name] = gmat
@@ -553,12 +554,13 @@ def srl_materials(materials):
             return os.path.basename(m.active_texture.image.filepath)
         return None
 
-    return {m.name: 
+    return {m.name:
                 {"texture": texture_name(m),
                  "alpha_blend": "ALPHA" if m.use_transparency else "OPAQUE",
                  "color": list(m.diffuse_color),
                  "opacity": m.alpha,
                  "shadeless": m.use_shadeless,
+                 "emit": m.emit,
                  "backface_culling": m.game_settings.use_backface_culling}
             for m in materials}
 

--- a/blender/bdx/gen/shaders/3d/default.frag
+++ b/blender/bdx/gen/shaders/3d/default.frag
@@ -1,0 +1,201 @@
+#ifdef GL_ES 
+#define LOWP lowp
+#define MED mediump
+#define HIGH highp
+precision mediump float;
+#else
+#define MED
+#define LOWP
+#define HIGH
+#endif
+
+#if defined(specularTextureFlag) || defined(specularColorFlag)
+#define specularFlag
+#endif
+
+#ifdef normalFlag
+varying vec3 v_normal;
+#endif //normalFlag
+
+#if defined(colorFlag)
+varying vec4 v_color;
+#endif
+
+#ifdef blendedFlag
+varying float v_opacity;
+#ifdef alphaTestFlag
+varying float v_alphaTest;
+#endif //alphaTestFlag
+#endif //blendedFlag
+
+#if defined(diffuseTextureFlag) || defined(specularTextureFlag)
+#define textureFlag
+#endif
+
+#ifdef diffuseTextureFlag
+varying MED vec2 v_diffuseUV;
+#endif
+
+#ifdef specularTextureFlag
+varying MED vec2 v_specularUV;
+#endif
+
+#ifdef diffuseColorFlag
+uniform vec4 u_diffuseColor;
+#endif
+
+#ifdef diffuseTextureFlag
+uniform sampler2D u_diffuseTexture;
+#endif
+
+#ifdef specularColorFlag
+uniform vec4 u_specularColor;
+#endif
+
+#ifdef specularTextureFlag
+uniform sampler2D u_specularTexture;
+#endif
+
+#ifdef normalTextureFlag
+uniform sampler2D u_normalTexture;
+#endif
+
+#ifdef lightingFlag
+varying vec3 v_lightDiffuse;
+
+#if	defined(ambientLightFlag) || defined(ambientCubemapFlag) || defined(sphericalHarmonicsFlag)
+#define ambientFlag
+#endif //ambientFlag
+
+#ifdef specularFlag
+varying vec3 v_lightSpecular;
+#endif //specularFlag
+
+#ifdef shadowMapFlag
+uniform sampler2D u_shadowTexture;
+uniform float u_shadowPCFOffset;
+varying vec3 v_shadowMapUv;
+#define separateAmbientFlag
+
+float getShadowness(vec2 offset)
+{
+    const vec4 bitShifts = vec4(1.0, 1.0 / 255.0, 1.0 / 65025.0, 1.0 / 160581375.0);
+    return step(v_shadowMapUv.z, dot(texture2D(u_shadowTexture, v_shadowMapUv.xy + offset), bitShifts));//+(1.0/255.0));	
+}
+
+float getShadow() 
+{
+	return (//getShadowness(vec2(0,0)) + 
+			getShadowness(vec2(u_shadowPCFOffset, u_shadowPCFOffset)) +
+			getShadowness(vec2(-u_shadowPCFOffset, u_shadowPCFOffset)) +
+			getShadowness(vec2(u_shadowPCFOffset, -u_shadowPCFOffset)) +
+			getShadowness(vec2(-u_shadowPCFOffset, -u_shadowPCFOffset))) * 0.25;
+}
+#endif //shadowMapFlag
+
+#if defined(ambientFlag) && defined(separateAmbientFlag)
+varying vec3 v_ambientLight;
+#endif //separateAmbientFlag
+
+#endif //lightingFlag
+
+#ifdef fogFlag
+uniform vec4 u_fogColor;
+varying float v_fog;
+#endif // fogFlag
+
+
+
+uniform int u_shadeless;
+uniform vec4 u_tintColor;
+
+void main() {
+	#if defined(normalFlag) 
+		vec3 normal = v_normal;
+	#endif // normalFlag
+		
+	#if defined(diffuseTextureFlag) && defined(diffuseColorFlag) && defined(colorFlag)
+		vec4 diffuse = texture2D(u_diffuseTexture, v_diffuseUV) * u_diffuseColor * v_color;
+	#elif defined(diffuseTextureFlag) && defined(diffuseColorFlag)
+		vec4 diffuse = texture2D(u_diffuseTexture, v_diffuseUV) * u_diffuseColor;
+	#elif defined(diffuseTextureFlag) && defined(colorFlag)
+		vec4 diffuse = texture2D(u_diffuseTexture, v_diffuseUV) * v_color;
+	#elif defined(diffuseTextureFlag)
+		vec4 diffuse = texture2D(u_diffuseTexture, v_diffuseUV);
+	#elif defined(diffuseColorFlag) && defined(colorFlag)
+		vec4 diffuse = u_diffuseColor * v_color;
+	#elif defined(diffuseColorFlag)
+		vec4 diffuse = u_diffuseColor;
+	#elif defined(colorFlag)
+		vec4 diffuse = v_color;
+	#else
+		vec4 diffuse = vec4(1.0);
+	#endif
+
+	diffuse.rgb += u_tintColor.rgb;
+
+	if (u_shadeless == 1)
+		gl_FragColor.rgb = diffuse.rgb;
+	else
+	{
+		#if (!defined(lightingFlag))
+			gl_FragColor.rgb = diffuse.rgb;
+		#elif (!defined(specularFlag))
+			#if defined(ambientFlag) && defined(separateAmbientFlag)
+				#ifdef shadowMapFlag
+					gl_FragColor.rgb = (diffuse.rgb * (v_ambientLight + getShadow() * v_lightDiffuse));
+					//gl_FragColor.rgb = texture2D(u_shadowTexture, v_shadowMapUv.xy);
+				#else
+					gl_FragColor.rgb = (diffuse.rgb * (v_ambientLight + v_lightDiffuse));
+				#endif //shadowMapFlag
+			#else
+				#ifdef shadowMapFlag
+					gl_FragColor.rgb = getShadow() * (diffuse.rgb * v_lightDiffuse);
+				#else
+					gl_FragColor.rgb = (diffuse.rgb * v_lightDiffuse);
+				#endif //shadowMapFlag
+			#endif
+		#else
+			#if defined(specularTextureFlag) && defined(specularColorFlag)
+				vec3 specular = texture2D(u_specularTexture, v_specularUV).rgb * u_specularColor.rgb * v_lightSpecular;
+			#elif defined(specularTextureFlag)
+				vec3 specular = texture2D(u_specularTexture, v_specularUV).rgb * v_lightSpecular;
+			#elif defined(specularColorFlag)
+				vec3 specular = u_specularColor.rgb * v_lightSpecular;
+			#else
+				vec3 specular = v_lightSpecular;
+			#endif
+
+			#if defined(ambientFlag) && defined(separateAmbientFlag)
+				#ifdef shadowMapFlag
+				gl_FragColor.rgb = (diffuse.rgb * (getShadow() * v_lightDiffuse + v_ambientLight)) + specular;
+					//gl_FragColor.rgb = texture2D(u_shadowTexture, v_shadowMapUv.xy);
+				#else
+					gl_FragColor.rgb = (diffuse.rgb * (v_lightDiffuse + v_ambientLight)) + specular;
+				#endif //shadowMapFlag
+			#else
+				#ifdef shadowMapFlag
+					gl_FragColor.rgb = getShadow() * ((diffuse.rgb * v_lightDiffuse) + specular);
+				#else
+					gl_FragColor.rgb = (diffuse.rgb * v_lightDiffuse) + specular;
+				#endif //shadowMapFlag
+			#endif
+		#endif //lightingFlag
+
+	}
+
+	#ifdef fogFlag
+		gl_FragColor.rgb = mix(gl_FragColor.rgb, u_fogColor.rgb, v_fog);
+	#endif // end fogFlag
+
+	#ifdef blendedFlag
+		gl_FragColor.a = diffuse.a * v_opacity;
+		#ifdef alphaTestFlag
+			if (gl_FragColor.a <= v_alphaTest)
+				discard;
+		#endif
+	#else
+		gl_FragColor.a = 1.0;
+	#endif
+
+}

--- a/blender/bdx/gen/shaders/3d/default.vert
+++ b/blender/bdx/gen/shaders/3d/default.vert
@@ -1,0 +1,336 @@
+#if defined(diffuseTextureFlag) || defined(specularTextureFlag)
+#define textureFlag
+#endif
+
+#if defined(specularTextureFlag) || defined(specularColorFlag)
+#define specularFlag
+#endif
+
+#if defined(specularFlag) || defined(fogFlag)
+#define cameraPositionFlag
+#endif
+
+attribute vec3 a_position;
+uniform mat4 u_projViewTrans;
+
+#if defined(colorFlag)
+varying vec4 v_color;
+attribute vec4 a_color;
+#endif // colorFlag
+
+#ifdef normalFlag
+attribute vec3 a_normal;
+uniform mat3 u_normalMatrix;
+varying vec3 v_normal;
+#endif // normalFlag
+
+#ifdef textureFlag
+attribute vec2 a_texCoord0;
+#endif // textureFlag
+
+#ifdef diffuseTextureFlag
+uniform vec4 u_diffuseUVTransform;
+varying vec2 v_diffuseUV;
+#endif
+
+#ifdef specularTextureFlag
+uniform vec4 u_specularUVTransform;
+varying vec2 v_specularUV;
+#endif
+
+#ifdef boneWeight0Flag
+#define boneWeightsFlag
+attribute vec2 a_boneWeight0;
+#endif //boneWeight0Flag
+
+#ifdef boneWeight1Flag
+#ifndef boneWeightsFlag
+#define boneWeightsFlag
+#endif
+attribute vec2 a_boneWeight1;
+#endif //boneWeight1Flag
+
+#ifdef boneWeight2Flag
+#ifndef boneWeightsFlag
+#define boneWeightsFlag
+#endif
+attribute vec2 a_boneWeight2;
+#endif //boneWeight2Flag
+
+#ifdef boneWeight3Flag
+#ifndef boneWeightsFlag
+#define boneWeightsFlag
+#endif
+attribute vec2 a_boneWeight3;
+#endif //boneWeight3Flag
+
+#ifdef boneWeight4Flag
+#ifndef boneWeightsFlag
+#define boneWeightsFlag
+#endif
+attribute vec2 a_boneWeight4;
+#endif //boneWeight4Flag
+
+#ifdef boneWeight5Flag
+#ifndef boneWeightsFlag
+#define boneWeightsFlag
+#endif
+attribute vec2 a_boneWeight5;
+#endif //boneWeight5Flag
+
+#ifdef boneWeight6Flag
+#ifndef boneWeightsFlag
+#define boneWeightsFlag
+#endif
+attribute vec2 a_boneWeight6;
+#endif //boneWeight6Flag
+
+#ifdef boneWeight7Flag
+#ifndef boneWeightsFlag
+#define boneWeightsFlag
+#endif
+attribute vec2 a_boneWeight7;
+#endif //boneWeight7Flag
+
+#if defined(numBones) && defined(boneWeightsFlag)
+#if (numBones > 0) 
+#define skinningFlag
+#endif
+#endif
+
+uniform mat4 u_worldTrans;
+
+#if defined(numBones)
+#if numBones > 0
+uniform mat4 u_bones[numBones];
+#endif //numBones
+#endif
+
+#ifdef shininessFlag
+uniform float u_shininess;
+#else
+const float u_shininess = 20.0;
+#endif // shininessFlag
+
+#ifdef blendedFlag
+uniform float u_opacity;
+varying float v_opacity;
+
+#ifdef alphaTestFlag
+uniform float u_alphaTest;
+varying float v_alphaTest;
+#endif //alphaTestFlag
+#endif // blendedFlag
+
+#ifdef lightingFlag
+varying vec3 v_lightDiffuse;
+
+#ifdef ambientLightFlag
+uniform vec3 u_ambientLight;
+#endif // ambientLightFlag
+
+#ifdef ambientCubemapFlag
+uniform vec3 u_ambientCubemap[6];
+#endif // ambientCubemapFlag 
+
+#ifdef sphericalHarmonicsFlag
+uniform vec3 u_sphericalHarmonics[9];
+#endif //sphericalHarmonicsFlag
+
+#ifdef specularFlag
+varying vec3 v_lightSpecular;
+#endif // specularFlag
+
+#ifdef cameraPositionFlag
+uniform vec4 u_cameraPosition;
+#endif // cameraPositionFlag
+
+#ifdef fogFlag
+varying float v_fog;
+#endif // fogFlag
+
+
+#if defined(numDirectionalLights) && (numDirectionalLights > 0)
+struct DirectionalLight
+{
+	vec3 color;
+	vec3 direction;
+};
+uniform DirectionalLight u_dirLights[numDirectionalLights];
+#endif // numDirectionalLights
+
+#if defined(numPointLights) && (numPointLights > 0)
+struct PointLight
+{
+	vec3 color;
+	vec3 position;
+};
+uniform PointLight u_pointLights[numPointLights];
+#endif // numPointLights
+
+#if	defined(ambientLightFlag) || defined(ambientCubemapFlag) || defined(sphericalHarmonicsFlag)
+#define ambientFlag
+#endif //ambientFlag
+
+#ifdef shadowMapFlag
+uniform mat4 u_shadowMapProjViewTrans;
+varying vec3 v_shadowMapUv;
+#define separateAmbientFlag
+#endif //shadowMapFlag
+
+#if defined(ambientFlag) && defined(separateAmbientFlag)
+varying vec3 v_ambientLight;
+#endif //separateAmbientFlag
+
+#endif // lightingFlag
+
+void main() {
+	#ifdef diffuseTextureFlag
+		v_diffuseUV = u_diffuseUVTransform.xy + a_texCoord0 * u_diffuseUVTransform.zw;
+	#endif //diffuseTextureFlag
+	
+	#ifdef specularTextureFlag
+		v_specularUV = u_specularUVTransform.xy + a_texCoord0 * u_specularUVTransform.zw;
+	#endif //specularTextureFlag
+	
+	#if defined(colorFlag)
+		v_color = a_color;
+	#endif // colorFlag
+		
+	#ifdef blendedFlag
+		v_opacity = u_opacity;
+		#ifdef alphaTestFlag
+			v_alphaTest = u_alphaTest;
+		#endif //alphaTestFlag
+	#endif // blendedFlag
+	
+	#ifdef skinningFlag
+		mat4 skinning = mat4(0.0);
+		#ifdef boneWeight0Flag
+			skinning += (a_boneWeight0.y) * u_bones[int(a_boneWeight0.x)];
+		#endif //boneWeight0Flag
+		#ifdef boneWeight1Flag				
+			skinning += (a_boneWeight1.y) * u_bones[int(a_boneWeight1.x)];
+		#endif //boneWeight1Flag
+		#ifdef boneWeight2Flag		
+			skinning += (a_boneWeight2.y) * u_bones[int(a_boneWeight2.x)];
+		#endif //boneWeight2Flag
+		#ifdef boneWeight3Flag
+			skinning += (a_boneWeight3.y) * u_bones[int(a_boneWeight3.x)];
+		#endif //boneWeight3Flag
+		#ifdef boneWeight4Flag
+			skinning += (a_boneWeight4.y) * u_bones[int(a_boneWeight4.x)];
+		#endif //boneWeight4Flag
+		#ifdef boneWeight5Flag
+			skinning += (a_boneWeight5.y) * u_bones[int(a_boneWeight5.x)];
+		#endif //boneWeight5Flag
+		#ifdef boneWeight6Flag
+			skinning += (a_boneWeight6.y) * u_bones[int(a_boneWeight6.x)];
+		#endif //boneWeight6Flag
+		#ifdef boneWeight7Flag
+			skinning += (a_boneWeight7.y) * u_bones[int(a_boneWeight7.x)];
+		#endif //boneWeight7Flag
+	#endif //skinningFlag
+
+	#ifdef skinningFlag
+		vec4 pos = u_worldTrans * skinning * vec4(a_position, 1.0);
+	#else
+		vec4 pos = u_worldTrans * vec4(a_position, 1.0);
+	#endif
+		
+	gl_Position = u_projViewTrans * pos;
+		
+	#ifdef shadowMapFlag
+		vec4 spos = u_shadowMapProjViewTrans * pos;
+		v_shadowMapUv.xy = (spos.xy / spos.w) * 0.5 + 0.5;
+		v_shadowMapUv.z = min(spos.z * 0.5 + 0.5, 0.998);
+	#endif //shadowMapFlag
+	
+	#if defined(normalFlag)
+		#if defined(skinningFlag)
+			vec3 normal = normalize((u_worldTrans * skinning * vec4(a_normal, 0.0)).xyz);
+		#else
+			vec3 normal = normalize(u_normalMatrix * a_normal);
+		#endif
+		v_normal = normal;
+	#endif // normalFlag
+
+    #ifdef fogFlag
+        vec3 flen = u_cameraPosition.xyz - pos.xyz;
+        float fog = dot(flen, flen) * u_cameraPosition.w;
+        v_fog = min(fog, 1.0);
+    #endif
+
+	#ifdef lightingFlag
+		#if	defined(ambientLightFlag)
+        	vec3 ambientLight = u_ambientLight;
+		#elif defined(ambientFlag)
+        	vec3 ambientLight = vec3(0.0);
+		#endif
+			
+		#ifdef ambientCubemapFlag 		
+			vec3 squaredNormal = normal * normal;
+			vec3 isPositive  = step(0.0, normal);
+			ambientLight += squaredNormal.x * mix(u_ambientCubemap[0], u_ambientCubemap[1], isPositive.x) +
+					squaredNormal.y * mix(u_ambientCubemap[2], u_ambientCubemap[3], isPositive.y) +
+					squaredNormal.z * mix(u_ambientCubemap[4], u_ambientCubemap[5], isPositive.z);
+		#endif // ambientCubemapFlag
+
+		#ifdef sphericalHarmonicsFlag
+			ambientLight += u_sphericalHarmonics[0];
+			ambientLight += u_sphericalHarmonics[1] * normal.x;
+			ambientLight += u_sphericalHarmonics[2] * normal.y;
+			ambientLight += u_sphericalHarmonics[3] * normal.z;
+			ambientLight += u_sphericalHarmonics[4] * (normal.x * normal.z);
+			ambientLight += u_sphericalHarmonics[5] * (normal.z * normal.y);
+			ambientLight += u_sphericalHarmonics[6] * (normal.y * normal.x);
+			ambientLight += u_sphericalHarmonics[7] * (3.0 * normal.z * normal.z - 1.0);
+			ambientLight += u_sphericalHarmonics[8] * (normal.x * normal.x - normal.y * normal.y);			
+		#endif // sphericalHarmonicsFlag
+
+		#ifdef ambientFlag
+			#ifdef separateAmbientFlag
+				v_ambientLight = ambientLight;
+				v_lightDiffuse = vec3(0.0);
+			#else
+				v_lightDiffuse = ambientLight;
+			#endif //separateAmbientFlag
+		#else
+	        v_lightDiffuse = vec3(0.0);
+		#endif //ambientFlag
+
+			
+		#ifdef specularFlag
+			v_lightSpecular = vec3(0.0);
+			vec3 viewVec = normalize(u_cameraPosition.xyz - pos.xyz);
+		#endif // specularFlag
+			
+		#if defined(numDirectionalLights) && (numDirectionalLights > 0) && defined(normalFlag)
+			for (int i = 0; i < numDirectionalLights; i++) {
+				vec3 lightDir = -u_dirLights[i].direction;
+				float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
+				vec3 value = u_dirLights[i].color * NdotL;
+				v_lightDiffuse += value;
+				#ifdef specularFlag
+					float halfDotView = max(0.0, dot(normal, normalize(lightDir + viewVec)));
+					v_lightSpecular += value * pow(halfDotView, u_shininess);
+				#endif // specularFlag
+			}
+		#endif // numDirectionalLights
+
+		#if defined(numPointLights) && (numPointLights > 0) && defined(normalFlag)
+			for (int i = 0; i < numPointLights; i++) {
+				vec3 lightDir = u_pointLights[i].position - pos.xyz;
+				float dist2 = dot(lightDir, lightDir);
+				lightDir *= inversesqrt(dist2);
+				float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
+				vec3 value = u_pointLights[i].color * (NdotL / (1.0 + dist2));
+				v_lightDiffuse += value;
+				#ifdef specularFlag
+					float halfDotView = max(0.0, dot(normal, normalize(lightDir + viewVec)));
+					v_lightSpecular += value * pow(halfDotView, u_shininess);
+				#endif // specularFlag
+			}
+		#endif // numPointLights
+	#endif // lightingFlag
+}

--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -8,6 +8,8 @@ import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.g2d.*;
 import com.badlogic.gdx.graphics.g3d.*;
 import com.badlogic.gdx.graphics.g3d.attributes.BlendingAttribute;
+import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
+import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute;
 import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
 import com.badlogic.gdx.graphics.g3d.utils.DefaultShaderProvider;
 import com.nilunder.bdx.inputs.*;
@@ -90,10 +92,13 @@ public class Bdx{
 
 	}
 
-	private static class BDXDefaultShader extends DefaultShader {
+	public static class BDXDefaultShader extends DefaultShader {
+
+		public final int u_shadeless = register("u_shadeless");
+		public final int u_tintColor = register("u_tintColor");
 
 		public BDXDefaultShader(Renderable renderable) {
-			super(renderable);
+			super(renderable, new DefaultShader.Config(Gdx.files.internal("bdx/shaders/3d/default.vert").readString(), Gdx.files.internal("bdx/shaders/3d/default.frag").readString()));
 		}
 
 		public void render(Renderable renderable, Attributes combinedAttributes)
@@ -101,6 +106,18 @@ public class Bdx{
 			BlendingAttribute ba = (BlendingAttribute) renderable.material.get(BlendingAttribute.Type);
 			
 			Gdx.gl.glBlendFuncSeparate(ba.sourceFunction, ba.destFunction, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+
+			IntAttribute shadeless = (IntAttribute) renderable.material.get(Scene.ShadelessAttribute.Shadeless);
+
+			set(u_shadeless, 0);
+			if (shadeless != null)
+				set(u_shadeless, shadeless.value);
+
+			ColorAttribute tint = (ColorAttribute) renderable.material.get(Scene.TintColorAttribute.Tint);
+
+			set(u_tintColor, 0, 0, 0, 0);
+			if (tint != null)
+				set(u_tintColor, tint.color);
 
 			super.render(renderable, combinedAttributes);
 		}
@@ -112,7 +129,6 @@ public class Bdx{
 		protected Shader createShader(Renderable renderable) {
 			if (matShaders.containsKey(renderable.material.id))
 				return matShaders.get(renderable.material.id).getShader(renderable);
-			
 			return new BDXDefaultShader(renderable);
 		}
 	}

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -30,7 +30,6 @@ import com.bulletphysics.dynamics.RigidBody;
 import com.bulletphysics.linearmath.MatrixUtil;
 import com.bulletphysics.linearmath.Transform;
 
-import com.nilunder.bdx.Bdx;
 import com.nilunder.bdx.utils.*;
 
 public class GameObject implements Named{
@@ -121,7 +120,7 @@ public class GameObject implements Named{
 
 	public void parent(GameObject p, boolean compound){
 		CompoundShape compShapeOld = null;
-		
+
 		if (parent != null){
 			parent.children.remove(this);
 
@@ -133,17 +132,17 @@ public class GameObject implements Named{
 					scene.world.addRigidBody(parent.body);
 				}
 			}
-			
+
 		}else if (p == null){
 			return;
 		}
-		
+
 		parent = p;
 
 		if (parent != null){
-			
+
 			parent.children.add(this);
-			
+
 			updateLocalTransform();
 			updateLocalScale();
 
@@ -156,11 +155,11 @@ public class GameObject implements Named{
 			}else{
 				dynamics(false);
 			}
-			
+
 		}else if (currBodyType.equals("STATIC") || currBodyType.equals("SENSOR")){
 			if (compound && compShapeOld != null)
 				scene.world.addRigidBody(body);
-			
+
 		}else{
 			dynamics(true);
 		}
@@ -692,10 +691,6 @@ public class GameObject implements Named{
 			child.color(r, g, b, a);
 	}
 
-	public void color(float r, float g, float b){
-		color(r, g, b, 1);
-	}
-
 	public void color(Vector4f color){
 		color(color.x, color.y, color.z, color.w);
 	}
@@ -706,12 +701,41 @@ public class GameObject implements Named{
 			ca.color.set(r, g, b, a);
 		}
 	}
-	
-	public void colorNoChildren(float r, float g, float b){
-		colorNoChildren(r, g, b, 1);
-	}
+
 	public void colorNoChildren(Vector4f color){
 		colorNoChildren(color.x, color.y, color.z, color.w);
+	}
+
+	public Vector3f tint(){
+
+		ColorAttribute ta = (ColorAttribute) modelInstance.materials.get(0).get(Scene.TintColorAttribute.Tint);
+		return new Vector3f(ta.color.r, ta.color.g, ta.color.b);
+
+	}
+
+	public void tint(float r, float g, float b){
+
+		tintNoChildren(r, g, b);
+		for (GameObject child : children)
+			child.tint(r, g, b);
+
+	}
+
+	public void tint(Vector3f color){
+		tint(color.x, color.y, color.z);
+	}
+
+	public void tintNoChildren(float r, float g, float b){
+
+		for (Material mat : modelInstance.materials) {
+			ColorAttribute ta = (ColorAttribute) modelInstance.materials.get(0).get(Scene.TintColorAttribute.Tint);
+			ta.color.set(r, g, b, 1);
+		}
+
+	}
+
+	public void tintNoChildren(Vector3f color) {
+		tintNoChildren(color.x, color.y, color.z);
 	}
 
 	public int[] blendMode(){
@@ -732,6 +756,16 @@ public class GameObject implements Named{
 
 		}
 
+	}
+
+	public boolean shadeless(){
+		IntAttribute sa = (IntAttribute) modelInstance.materials.first().get(Scene.ShadelessAttribute.Shadeless);
+		return sa.value == 1;
+	}
+
+	public void shadeless(boolean shadeless){
+		IntAttribute sa = (IntAttribute) modelInstance.materials.first().get(Scene.ShadelessAttribute.Shadeless);
+		sa.value = shadeless ? 1 : 0;
 	}
 
 	public String modelName(){

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -37,7 +37,6 @@ import com.bulletphysics.linearmath.Transform;
 import com.nilunder.bdx.utils.*;
 import com.nilunder.bdx.inputs.*;
 import com.nilunder.bdx.components.*;
-import com.nilunder.bdx.Bdx;
 import com.nilunder.bdx.GameObject.ArrayListGameObject;
 
 public class Scene implements Named{
@@ -99,6 +98,32 @@ public class Scene implements Named{
 		return name;
 	}
 
+	public static class ShadelessAttribute extends IntAttribute {
+
+		public final static String ShadelessAlias = "Shadeless";
+		public final static long Shadeless = register(ShadelessAlias);
+
+		public ShadelessAttribute(){
+			super(Shadeless, 0);
+		}
+
+	};
+
+	public static class TintColorAttribute extends ColorAttribute {
+
+		public final static String TintAlias = "Tint";
+		public final static long Tint = register(TintAlias);
+
+		static {
+			Mask = Mask | Tint;
+		}
+
+		private TintColorAttribute(float r, float g, float b){
+			super(Tint, r, g, b, 0);
+		}
+
+	}
+
 	public void init(){
 		requestedRestart = false;
 		paused = false;
@@ -146,12 +171,21 @@ public class Scene implements Named{
 
 			float[] c = mat.get("color").asFloatArray();
 			Material material = new Material(ColorAttribute.createDiffuse(c[0], c[1], c[2], 1));
-							
-			material.id = mat.name;
-			
+
+			material.set(new TintColorAttribute(0, 0, 0));
+
+			IntAttribute shadeless = (IntAttribute) new ShadelessAttribute();
+
 			if (mat.get("shadeless").asBoolean())
-				material.set(new ColorAttribute(ColorAttribute.AmbientLight, 1, 1, 1, 1));
-			
+				shadeless.value = 1;
+
+			material.set(shadeless);
+
+			material.id = mat.name;
+
+			float ambientStrength = mat.get("emit").asFloat();
+			material.set(new ColorAttribute(ColorAttribute.AmbientLight, ambientStrength, ambientStrength, ambientStrength, ambientStrength));
+
 			if (mat.get("backface_culling").asBoolean())
 				material.set(new IntAttribute(IntAttribute.CullFace, GL20.GL_BACK));
 			else


### PR DESCRIPTION
Shadeless-ness is now absolute and correct (Fixes #390).

The emit slider now adjusts how dark objects start off at while still remaining lit.

tint() and tintNoChildren() functions allow color tinting (additive vs. multiplicative) of objects.

Getting rid of mostly unnecessary extra color() functions (the ones without alpha values).

The 3D vert and frag shader files are now available in the android/assets/bdx/shaders/3d/ directory. They are automatically loaded and used as a default, of course.