### PR TITLE
(#464) - Make Emit work independently of ambient lighting.

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -752,9 +752,8 @@ def export(context, filepath, scene_name, exprun):
 
     if scene.world != None:
         ambient_color = list(scene.world.ambient_color)
-        ambient_color.append(1)
     else:
-        ambient_color = [0,0,0,1]
+        ambient_color = [0.0, 0.0, 0.0]
 
     bdx = {
         "name": scene.name,

--- a/blender/bdx/gen/shaders/3d/default.frag
+++ b/blender/bdx/gen/shaders/3d/default.frag
@@ -108,6 +108,7 @@ varying float v_fog;
 
 uniform int u_shadeless;
 uniform vec4 u_tintColor;
+uniform vec4 u_emitColor;
 
 void main() {
 	#if defined(normalFlag) 
@@ -143,41 +144,41 @@ void main() {
 		#elif (!defined(specularFlag))
 			#if defined(ambientFlag) && defined(separateAmbientFlag)
 				#ifdef shadowMapFlag
-					gl_FragColor.rgb = (diffuse.rgb * (v_ambientLight + getShadow() * v_lightDiffuse));
+					gl_FragColor.rgb = (diffuse.rgb * (v_ambientLight + u_emitColor.rgb + getShadow() * v_lightDiffuse));
 					//gl_FragColor.rgb = texture2D(u_shadowTexture, v_shadowMapUv.xy);
 				#else
-					gl_FragColor.rgb = (diffuse.rgb * (v_ambientLight + v_lightDiffuse));
+					gl_FragColor.rgb = (diffuse.rgb * (v_ambientLight + u_emitColor.rgb + v_lightDiffuse));
 				#endif //shadowMapFlag
 			#else
 				#ifdef shadowMapFlag
-					gl_FragColor.rgb = getShadow() * (diffuse.rgb * v_lightDiffuse);
+					gl_FragColor.rgb = getShadow() * (diffuse.rgb * (v_lightDiffuse + u_emitColor.rgb));
 				#else
-					gl_FragColor.rgb = (diffuse.rgb * v_lightDiffuse);
+					gl_FragColor.rgb = (diffuse.rgb * (v_lightDiffuse + u_emitColor.rgb));
 				#endif //shadowMapFlag
 			#endif
 		#else
 			#if defined(specularTextureFlag) && defined(specularColorFlag)
-				vec3 specular = texture2D(u_specularTexture, v_specularUV).rgb * u_specularColor.rgb * v_lightSpecular;
+				vec3 specular = texture2D(u_specularTexture, v_specularUV).rgb * u_specularColor.rgb * (v_lightSpecular + u_emitColor.rgb);
 			#elif defined(specularTextureFlag)
-				vec3 specular = texture2D(u_specularTexture, v_specularUV).rgb * v_lightSpecular;
+				vec3 specular = texture2D(u_specularTexture, v_specularUV).rgb * (v_lightSpecular + u_emitColor.rgb);
 			#elif defined(specularColorFlag)
-				vec3 specular = u_specularColor.rgb * v_lightSpecular;
+				vec3 specular = u_specularColor.rgb * (v_lightSpecular + u_emitColor.rgb);
 			#else
-				vec3 specular = v_lightSpecular;
+				vec3 specular = v_lightSpecular + u_emitColor.rgb;
 			#endif
 
 			#if defined(ambientFlag) && defined(separateAmbientFlag)
 				#ifdef shadowMapFlag
-				gl_FragColor.rgb = (diffuse.rgb * (getShadow() * v_lightDiffuse + v_ambientLight)) + specular;
+				gl_FragColor.rgb = (diffuse.rgb * (getShadow() * v_lightDiffuse + u_emitColor.rgb + v_ambientLight)) + specular;
 					//gl_FragColor.rgb = texture2D(u_shadowTexture, v_shadowMapUv.xy);
 				#else
-					gl_FragColor.rgb = (diffuse.rgb * (v_lightDiffuse + v_ambientLight)) + specular;
+					gl_FragColor.rgb = (diffuse.rgb * (v_lightDiffuse + u_emitColor.rgb + v_ambientLight)) + specular;
 				#endif //shadowMapFlag
 			#else
 				#ifdef shadowMapFlag
-					gl_FragColor.rgb = getShadow() * ((diffuse.rgb * v_lightDiffuse) + specular);
+					gl_FragColor.rgb = getShadow() * ((diffuse.rgb * (v_lightDiffuse + u_emitColor.rgb)) + specular);
 				#else
-					gl_FragColor.rgb = (diffuse.rgb * v_lightDiffuse) + specular;
+					gl_FragColor.rgb = (diffuse.rgb * (v_lightDiffuse + u_emitColor.rgb)) + specular;
 				#endif //shadowMapFlag
 			#endif
 		#endif //lightingFlag

--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -96,6 +96,7 @@ public class Bdx{
 
 		public final int u_shadeless = register("u_shadeless");
 		public final int u_tintColor = register("u_tintColor");
+		public final int u_emitColor = register("u_emitColor");
 
 		public BDXDefaultShader(Renderable renderable) {
 			super(renderable, new DefaultShader.Config(Gdx.files.internal("bdx/shaders/3d/default.vert").readString(), Gdx.files.internal("bdx/shaders/3d/default.frag").readString()));
@@ -107,17 +108,23 @@ public class Bdx{
 			
 			Gdx.gl.glBlendFuncSeparate(ba.sourceFunction, ba.destFunction, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
-			IntAttribute shadeless = (IntAttribute) renderable.material.get(Scene.ShadelessAttribute.Shadeless);
+			IntAttribute shadeless = (IntAttribute) renderable.material.get(Scene.BDXIntAttribute.Shadeless);
 
 			set(u_shadeless, 0);
 			if (shadeless != null)
 				set(u_shadeless, shadeless.value);
 
-			ColorAttribute tint = (ColorAttribute) renderable.material.get(Scene.TintColorAttribute.Tint);
+			ColorAttribute tint = (ColorAttribute) renderable.material.get(Scene.BDXColorAttribute.Tint);
 
-			set(u_tintColor, 0, 0, 0, 0);
+			set(u_tintColor, 0, 0, 0);
 			if (tint != null)
 				set(u_tintColor, tint.color);
+
+			ColorAttribute emit = (ColorAttribute) renderable.material.get(Scene.BDXColorAttribute.Emit);
+
+			set(u_emitColor, 0, 0, 0);
+			if (emit != null)
+				set(u_emitColor, emit.color);
 
 			super.render(renderable, combinedAttributes);
 		}

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -708,7 +708,7 @@ public class GameObject implements Named{
 
 	public Vector3f tint(){
 
-		ColorAttribute ta = (ColorAttribute) modelInstance.materials.get(0).get(Scene.TintColorAttribute.Tint);
+		ColorAttribute ta = (ColorAttribute) modelInstance.materials.get(0).get(Scene.BDXColorAttribute.Tint);
 		return new Vector3f(ta.color.r, ta.color.g, ta.color.b);
 
 	}
@@ -728,7 +728,7 @@ public class GameObject implements Named{
 	public void tintNoChildren(float r, float g, float b){
 
 		for (Material mat : modelInstance.materials) {
-			ColorAttribute ta = (ColorAttribute) modelInstance.materials.get(0).get(Scene.TintColorAttribute.Tint);
+			ColorAttribute ta = (ColorAttribute) modelInstance.materials.get(0).get(Scene.BDXColorAttribute.Tint);
 			ta.color.set(r, g, b, 1);
 		}
 
@@ -759,12 +759,12 @@ public class GameObject implements Named{
 	}
 
 	public boolean shadeless(){
-		IntAttribute sa = (IntAttribute) modelInstance.materials.first().get(Scene.ShadelessAttribute.Shadeless);
+		IntAttribute sa = (IntAttribute) modelInstance.materials.first().get(Scene.BDXIntAttribute.Shadeless);
 		return sa.value == 1;
 	}
 
 	public void shadeless(boolean shadeless){
-		IntAttribute sa = (IntAttribute) modelInstance.materials.first().get(Scene.ShadelessAttribute.Shadeless);
+		IntAttribute sa = (IntAttribute) modelInstance.materials.first().get(Scene.BDXIntAttribute.Shadeless);
 		sa.value = shadeless ? 1 : 0;
 	}
 

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -98,28 +98,30 @@ public class Scene implements Named{
 		return name;
 	}
 
-	public static class ShadelessAttribute extends IntAttribute {
+	public static class BDXIntAttribute extends IntAttribute {
 
 		public final static String ShadelessAlias = "Shadeless";
 		public final static long Shadeless = register(ShadelessAlias);
 
-		public ShadelessAttribute(){
+		public BDXIntAttribute(){
 			super(Shadeless, 0);
 		}
 
 	};
 
-	public static class TintColorAttribute extends ColorAttribute {
+	public static class BDXColorAttribute extends ColorAttribute {
 
 		public final static String TintAlias = "Tint";
 		public final static long Tint = register(TintAlias);
+		public final static String EmitAlias = "Emit";
+		public final static long Emit = register(EmitAlias);
 
 		static {
-			Mask = Mask | Tint;
+			Mask = Mask | Tint | Emit;
 		}
 
-		private TintColorAttribute(float r, float g, float b){
-			super(Tint, r, g, b, 0);
+		private BDXColorAttribute(long type, float r, float g, float b){
+			super(type, r, g, b, 0);
 		}
 
 	}
@@ -162,7 +164,7 @@ public class Scene implements Named{
 		world = new DiscreteDynamicsWorld(dispatcher, broadphase, solver, collisionConfiguration);
 		world.setDebugDrawer(new Bullet.DebugDrawer(json.get("physviz").asBoolean()));
 		gravity(new Vector3f(0, 0, -json.get("gravity").asFloat()));
-		ambientLight(new Vector4f(json.get("ambientColor").asFloatArray()));
+		ambientLight(new Vector3f(json.get("ambientColor").asFloatArray()));
 
 		Bdx.profiler.init(json.get("framerateProfile").asBoolean());
 
@@ -172,9 +174,9 @@ public class Scene implements Named{
 			float[] c = mat.get("color").asFloatArray();
 			Material material = new Material(ColorAttribute.createDiffuse(c[0], c[1], c[2], 1));
 
-			material.set(new TintColorAttribute(0, 0, 0));
+			material.set(new BDXColorAttribute(BDXColorAttribute.Tint, 0, 0, 0));
 
-			IntAttribute shadeless = (IntAttribute) new ShadelessAttribute();
+			IntAttribute shadeless = (IntAttribute) new BDXIntAttribute();
 
 			if (mat.get("shadeless").asBoolean())
 				shadeless.value = 1;
@@ -183,8 +185,8 @@ public class Scene implements Named{
 
 			material.id = mat.name;
 
-			float ambientStrength = mat.get("emit").asFloat();
-			material.set(new ColorAttribute(ColorAttribute.AmbientLight, ambientStrength, ambientStrength, ambientStrength, ambientStrength));
+			float emitStrength = mat.get("emit").asFloat();
+			material.set(new BDXColorAttribute(BDXColorAttribute.Emit, emitStrength, emitStrength, emitStrength));
 
 			if (mat.get("backface_culling").asBoolean())
 				material.set(new IntAttribute(IntAttribute.CullFace, GL20.GL_BACK));
@@ -734,18 +736,18 @@ public class Scene implements Named{
 
 	}
 	
-	public void ambientLight(Vector4f color){
-		ambientLight(color.x, color.y, color.z, color.w);
+	public void ambientLight(Vector3f color){
+		ambientLight(color.x, color.y, color.z);
 	}
 	
-	public void ambientLight(float r, float g, float b, float a) {
+	public void ambientLight(float r, float g, float b) {
 		ColorAttribute ca = (ColorAttribute) environment.get(ColorAttribute.AmbientLight);
-		ca.color.set(r, g, b, a);
+		ca.color.set(r, g, b, 1);
 	}
 	
-	public Vector4f ambientLight(){
+	public Vector3f ambientLight(){
 		ColorAttribute ca = (ColorAttribute) environment.get(ColorAttribute.AmbientLight);
-		return new Vector4f(ca.color.r, ca.color.g, ca.color.b, ca.color.a);
+		return new Vector3f(ca.color.r, ca.color.g, ca.color.b);
 	}
 	
 	public void update(){


### PR DESCRIPTION
- Also, renamed the ShadelessAttribute and TintColorAttribute to the more generic "BDXIntAttribute" and "BDXColorAttribute" with Shadeless-ness, Tint, and Emit as types therein.

- Also, removed the alpha component from the scene.ambientLight() functions. The alpha component doesn't influence the ambient lighting color or intensity, so why have it in our functions?