### PR TITLE
(#235) - Various Shader-related fixes and improvements.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -8,11 +8,9 @@ import com.badlogic.gdx.files.*;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.g2d.*;
 import com.badlogic.gdx.graphics.g3d.*;
-import com.badlogic.gdx.graphics.g3d.attributes.BlendingAttribute;
-import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
-import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute;
-import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
-import com.badlogic.gdx.graphics.g3d.utils.DefaultShaderProvider;
+import com.nilunder.bdx.gl.BDXShaderProvider;
+import com.nilunder.bdx.gl.RenderBuffer;
+import com.nilunder.bdx.gl.ShaderProgram;
 import com.nilunder.bdx.inputs.*;
 import com.nilunder.bdx.audio.*;
 import com.nilunder.bdx.utils.*;
@@ -93,54 +91,6 @@ public class Bdx{
 
 	}
 
-	public static class BDXDefaultShader extends DefaultShader {
-
-		public final int u_shadeless = register("u_shadeless");
-		public final int u_tintColor = register("u_tintColor");
-		public final int u_emitColor = register("u_emitColor");
-
-		public BDXDefaultShader(Renderable renderable) {
-			super(renderable, new DefaultShader.Config(Gdx.files.internal("bdx/shaders/3d/default.vert").readString(), Gdx.files.internal("bdx/shaders/3d/default.frag").readString()));
-		}
-
-		public void render(Renderable renderable, Attributes combinedAttributes)
-		{
-			BlendingAttribute ba = (BlendingAttribute) renderable.material.get(BlendingAttribute.Type);
-			
-			Gdx.gl.glBlendFuncSeparate(ba.sourceFunction, ba.destFunction, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
-
-			IntAttribute shadeless = (IntAttribute) renderable.material.get(Scene.BDXIntAttribute.Shadeless);
-
-			set(u_shadeless, 0);
-			if (shadeless != null)
-				set(u_shadeless, shadeless.value);
-
-			ColorAttribute tint = (ColorAttribute) renderable.material.get(Scene.BDXColorAttribute.Tint);
-
-			set(u_tintColor, 0, 0, 0);
-			if (tint != null)
-				set(u_tintColor, tint.color);
-
-			ColorAttribute emit = (ColorAttribute) renderable.material.get(Scene.BDXColorAttribute.Emit);
-
-			set(u_emitColor, 0, 0, 0);
-			if (emit != null)
-				set(u_emitColor, emit.color);
-
-			super.render(renderable, combinedAttributes);
-		}
-		
-	}
-
-	private static class BDXShaderProvider extends DefaultShaderProvider {
-		@Override
-		protected Shader createShader(Renderable renderable) {
-			if (matShaders.containsKey(renderable.material.id))
-				return matShaders.get(renderable.material.id).getShader(renderable);
-			return new BDXDefaultShader(renderable);
-		}
-	}
-	
 	public static final float TICK_TIME = 1f/60f;
 	public static final int VERT_STRIDE = 8;
 	public static float time;
@@ -156,7 +106,7 @@ public class Bdx{
 	public static ArrayList<Finger> fingers;
 	public static ArrayList<Component> components;
 	public static HashMap<String, ShaderProgram> matShaders;
-	
+
 	private static ArrayList<Finger> allocatedFingers;
 	private static ModelBatch modelBatch;
 	private static RenderBuffer frameBuffer;
@@ -198,7 +148,6 @@ public class Bdx{
 		frameBuffer = new RenderBuffer(spriteBatch);
 		tempBuffer = new RenderBuffer(spriteBatch);
 	}
-
 
 	public static void main(){
 		profiler.start("__graphics");
@@ -315,9 +264,6 @@ public class Bdx{
 		spriteBatch.dispose();
 		frameBuffer.dispose();
 		tempBuffer.dispose();
-		for (ShaderProgram sp: matShaders.values()) {
-			sp.disposeAll();
-		}
 	}
 	
 	public static void end(){

--- a/src/com/nilunder/bdx/Light.java
+++ b/src/com/nilunder/bdx/Light.java
@@ -27,7 +27,6 @@ public class Light extends GameObject {
 			
 	public void color(float r, float g, float b, float a){
 		this.color = new Vector4f(r,g,b,a);
-		updateLight();
 	}
 	
 	public Vector4f color(){
@@ -36,7 +35,6 @@ public class Light extends GameObject {
 		
 	public void energy(float energy) {
 		this.energy = energy;
-		updateLight();
 	}
 	
 	public float energy(){

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -34,6 +34,8 @@ import com.bulletphysics.dynamics.DiscreteDynamicsWorld;
 import com.bulletphysics.dynamics.RigidBody;
 import com.bulletphysics.dynamics.constraintsolver.SequentialImpulseConstraintSolver;
 import com.bulletphysics.linearmath.Transform;
+import com.nilunder.bdx.gl.RenderBuffer;
+import com.nilunder.bdx.gl.ShaderProgram;
 import com.nilunder.bdx.utils.*;
 import com.nilunder.bdx.inputs.*;
 import com.nilunder.bdx.components.*;
@@ -220,13 +222,10 @@ public class Scene implements Named{
 			materials.put(mat.name, material);
 		}
 		
-		
 		for (JsonValue model: json.get("models")){
 			models.put(model.name, createModel(model));
 		}
-		
-		
-		
+
 		HashMap<String, JsonValue> fonts = new HashMap<>();
 		for (JsonValue fontj: json.get("fonts")){
 			String font = fontj.asString();
@@ -317,8 +316,8 @@ public class Scene implements Named{
 
 	public void dispose(){
 		lastFrameBuffer.dispose();
-		for (ShaderProgram sp : filters) {
-			sp.disposeAll();
+		for (ShaderProgram s : filters) {
+			s.dispose();
 		}
 	}
 	
@@ -391,6 +390,7 @@ public class Scene implements Named{
 			l.color(ll.color());
 			l.type = ll.type;
 			l.makeLightData();
+			l.updateLight();
 			environment.add(l.lightData);
 		}
 
@@ -681,6 +681,9 @@ public class Scene implements Named{
 			for (Texture t : textures.values()){
 				t.dispose();
 			}
+			for (ShaderProgram s : filters){
+				s.dispose();
+			}
 			init();
 		}
 
@@ -693,6 +696,8 @@ public class Scene implements Named{
 		for (GameObject g : objects){
 			if(!g.valid())
 				continue;
+			if (g instanceof Light)
+				((Light) g).updateLight();
 			for (Component c : g.components){
 				if (c.state != null)
 					c.state.main();

--- a/src/com/nilunder/bdx/gl/BDXShaderProvider.java
+++ b/src/com/nilunder/bdx/gl/BDXShaderProvider.java
@@ -1,0 +1,100 @@
+package com.nilunder.bdx.gl;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g3d.Attributes;
+import com.badlogic.gdx.graphics.g3d.Renderable;
+import com.badlogic.gdx.graphics.g3d.Shader;
+import com.badlogic.gdx.graphics.g3d.attributes.BlendingAttribute;
+import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
+import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute;
+import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
+import com.badlogic.gdx.graphics.g3d.utils.DefaultShaderProvider;
+import com.nilunder.bdx.Bdx;
+import com.nilunder.bdx.Scene;
+
+class BDXDefaultShader extends DefaultShader {
+
+	public final int u_shadeless = register("u_shadeless");
+	public final int u_tintColor = register("u_tintColor");
+	public final int u_emitColor = register("u_emitColor");
+
+	public boolean customized = false;
+
+	public BDXDefaultShader(Renderable renderable, Config config) {
+		super(renderable, config);
+	}
+
+	public BDXDefaultShader(Renderable renderable, DefaultShader.Config config, ShaderProgram shaderProgram) {
+		super(renderable, config, shaderProgram);
+	}
+
+	public void render(Renderable renderable, Attributes combinedAttributes)
+	{
+		BlendingAttribute ba = (BlendingAttribute) renderable.material.get(BlendingAttribute.Type);
+
+		Gdx.gl.glBlendFuncSeparate(ba.sourceFunction, ba.destFunction, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+
+		IntAttribute shadeless = (IntAttribute) renderable.material.get(Scene.BDXIntAttribute.Shadeless);
+
+		set(u_shadeless, 0);
+		if (shadeless != null)
+			set(u_shadeless, shadeless.value);
+
+		ColorAttribute tint = (ColorAttribute) renderable.material.get(Scene.BDXColorAttribute.Tint);
+
+		set(u_tintColor, 0, 0, 0);
+		if (tint != null)
+			set(u_tintColor, tint.color);
+
+		ColorAttribute emit = (ColorAttribute) renderable.material.get(Scene.BDXColorAttribute.Emit);
+
+		set(u_emitColor, 0, 0, 0);
+		if (emit != null)
+			set(u_emitColor, emit.color);
+
+		super.render(renderable, combinedAttributes);
+	}
+
+	public boolean canRender(Renderable renderable) {
+
+		String matName = renderable.material.id;
+
+		boolean hasCustomShader = Bdx.matShaders.containsKey(matName);	// Is there a custom shader for the rendered material?
+
+		if (hasCustomShader) {
+
+			if (Bdx.matShaders.get(matName) == program)					// Is this shader for that rendered material?
+				return true;											// If so, it can be used to render
+			else
+				return false;
+
+		}
+		else {															// This material doesn't have a custom shader.
+			if (customized)												// So never use a custom shader; always use an un-customized one.
+				return false;
+			else
+				return super.canRender(renderable);
+		}
+
+	}
+
+
+
+}
+
+public class BDXShaderProvider extends DefaultShaderProvider {
+
+	public Shader createShader(Renderable renderable) {
+
+		if (Bdx.matShaders.containsKey(renderable.material.id)) {
+			ShaderProgram sp = Bdx.matShaders.get(renderable.material.id);
+			BDXDefaultShader shader = new BDXDefaultShader(renderable, new DefaultShader.Config(), sp);
+			shader.customized = true;
+			return shader;
+		}
+
+		return new BDXDefaultShader(renderable, new DefaultShader.Config(Gdx.files.internal("bdx/shaders/3d/default.vert").readString(),
+				Gdx.files.internal("bdx/shaders/3d/default.frag").readString()));
+	}
+}

--- a/src/com/nilunder/bdx/gl/RenderBuffer.java
+++ b/src/com/nilunder/bdx/gl/RenderBuffer.java
@@ -1,4 +1,4 @@
-package com.nilunder.bdx.utils;
+package com.nilunder.bdx.gl;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
@@ -7,7 +7,6 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
-import com.nilunder.bdx.ShaderProgram;
 
 public class RenderBuffer extends FrameBuffer{
 		

--- a/src/com/nilunder/bdx/gl/ShaderProgram.java
+++ b/src/com/nilunder/bdx/gl/ShaderProgram.java
@@ -1,24 +1,18 @@
-package com.nilunder.bdx;
+package com.nilunder.bdx.gl;
 
 import javax.vecmath.Vector2f;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.graphics.g3d.Renderable;
-import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
-import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader.Config;
 
-/**
- * Created by SolarLune on 3/18/2015.
- */
 public class ShaderProgram extends com.badlogic.gdx.graphics.glutils.ShaderProgram {
-	
-	private DefaultShader shader;
+
 	public Vector2f renderScale;
 	public boolean overlay;
-	static public boolean nearestFiltering;
+	static public boolean nearestFiltering = false;
 	
 	public ShaderProgram(String vertexShader, String fragmentShader) {
+
 		super(vertexShader, fragmentShader);
 
 		if (!isCompiled()) {
@@ -27,7 +21,6 @@ public class ShaderProgram extends com.badlogic.gdx.graphics.glutils.ShaderProgr
 		
 		renderScale = new Vector2f(1, 1);
 		overlay = false;
-		nearestFiltering = false;
 	}
 	public ShaderProgram(FileHandle vertexShader, FileHandle fragmentShader) {
 		this(vertexShader.readString(), fragmentShader.readString());
@@ -35,23 +28,6 @@ public class ShaderProgram extends com.badlogic.gdx.graphics.glutils.ShaderProgr
 	
 	public static ShaderProgram load(String vertexPath, String fragmentPath) {
 		return new ShaderProgram(Gdx.files.internal(vertexPath), Gdx.files.internal(fragmentPath));
-	}
-		
-	public DefaultShader getShader(Renderable renderable){
-		
-		if (shader == null) {
-			shader = new DefaultShader(renderable, new Config(), this);
-			shader.init();
-		}
-		
-		return shader;
-	}
-
-	public void disposeAll(){
-		if (shader != null)
-			shader.dispose();
-		else
-			dispose();
 	}
 	
 }


### PR DESCRIPTION
Fixed bug where lights weren't updating (like, set a light to Dynamic before this commit and watch it float mysteriously). To do this, we update the light data every frame, alongside the object logic.

Moved the ShaderProvider and BDX Shader into a new file (BDXShaderProvider.java).

Cleaned up ShaderProgram, removing references to Shaders, as the Program doesn't need to have it anymore.

Moved nearestFiltering setting out of ShaderProgram constructor to prevent it being re-set with each ShaderProgram instantiation.

Added canRender() function to BDXDefaultShader, fixing a bug where LibGDX would re-use custom shaders for default materials.