### PR TITLE
(#235) Maximum light count improvements.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -106,6 +106,7 @@ public class Bdx{
 	public static ArrayList<Finger> fingers;
 	public static ArrayList<Component> components;
 	public static HashMap<String, ShaderProgram> matShaders;
+	public static BDXShaderProvider shaderProvider;
 
 	private static ArrayList<Finger> allocatedFingers;
 	private static ModelBatch modelBatch;
@@ -141,8 +142,9 @@ public class Bdx{
 		Gdx.input.setInputProcessor(new GdxProcessor(keyboard, mouse, allocatedFingers, gamepads));
 
 		com.badlogic.gdx.graphics.glutils.ShaderProgram.pedantic = false;
-		
-		modelBatch = new ModelBatch(new BDXShaderProvider());
+
+		shaderProvider = new BDXShaderProvider();
+		modelBatch = new ModelBatch(shaderProvider);
 		spriteBatch = new SpriteBatch();
 		spriteBatch.setBlendFunction(Gdx.gl.GL_SRC_ALPHA, Gdx.gl.GL_ONE_MINUS_SRC_ALPHA);
 		frameBuffer = new RenderBuffer(spriteBatch);
@@ -264,6 +266,7 @@ public class Bdx{
 		spriteBatch.dispose();
 		frameBuffer.dispose();
 		tempBuffer.dispose();
+		shaderProvider.dispose();
 	}
 	
 	public static void end(){
@@ -288,5 +291,5 @@ public class Bdx{
 			scene.lastFrameBuffer = new RenderBuffer(null);
 		}
 	}
-	
+
 }

--- a/src/com/nilunder/bdx/Light.java
+++ b/src/com/nilunder/bdx/Light.java
@@ -11,19 +11,26 @@ import com.badlogic.gdx.graphics.g3d.environment.BaseLight;
 import com.badlogic.gdx.graphics.g3d.environment.DirectionalLight;
 import com.badlogic.gdx.graphics.g3d.environment.PointLight;
 import com.badlogic.gdx.graphics.g3d.environment.SpotLight;
+import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
 
 public class Light extends GameObject {
 
-	public String type;
+	public Type type;
 	private float energy;
 	private Vector4f color;
 	public BaseLight lightData;
+
+	public enum Type {
+		POINT,
+		SUN,
+		SPOT
+	}
 	
 	public void makeLightData(){
 		
-		if (type.equals("POINT"))
+		if (type.equals(Type.POINT))
 			lightData = new PointLight();
-		else if (type.equals("SUN"))
+		else if (type.equals(Type.SUN))
 			lightData = new DirectionalLight();	
 		
 		updateLight();
@@ -47,11 +54,11 @@ public class Light extends GameObject {
 	
 	public void updateLight(){
 		if (lightData != null) {
-			if (type.equals("POINT")) {
+			if (type.equals(Type.POINT)) {
 				PointLight p = (PointLight)lightData;
 				p.set(color.x, color.y, color.z, position().x, position().y, position().z, energy * 10);
 			}
-			else if (type.equals("SUN")) {
+			else if (type.equals(Type.SUN)) {
 				DirectionalLight d = (DirectionalLight)lightData;
 				Vector3f dir = axis(2).negated();
 				d.set(color.x, color.y, color.z, dir.x, dir.y, dir.z);
@@ -62,11 +69,11 @@ public class Light extends GameObject {
 	@Override
 	public void endNoChildren(){
 
-		if (type.equals("POINT"))
+		if (type.equals(Type.POINT))
 			((PointLightsAttribute) scene.environment.get(PointLightsAttribute.Type)).lights.removeValue((PointLight) lightData, true);		// Remove the light from the environment
-		if (type.equals("SUN"))
+		if (type.equals(Type.SUN))
 			((DirectionalLightsAttribute) scene.environment.get(DirectionalLightsAttribute.Type)).lights.removeValue((DirectionalLight) lightData, true);
-		if (type.equals("SPOT"))
+		if (type.equals(Type.SPOT))
 			((SpotLightsAttribute) scene.environment.get(SpotLightsAttribute.Type)).lights.removeValue((SpotLight) lightData, true);
 
 		super.endNoChildren();
@@ -78,6 +85,30 @@ public class Light extends GameObject {
 		super.transform(mat, updateLocal);
 		
 		updateLight();
+	}
+
+	public static void setMaxCount(Type lightType, int count){
+		DefaultShader.Config config = Bdx.shaderProvider.config;
+
+		if (lightType.equals(Type.POINT))
+			config.numPointLights = count;
+		else if (lightType.equals(Type.SUN))
+			config.numDirectionalLights = count;
+		else
+			config.numSpotLights = count;
+
+		Bdx.shaderProvider.deleteShaders();			// Get rid of the old shaders, as they need to be recreated for the new light count.
+	}
+
+	public static int getMaxCount(Type lightType){
+		DefaultShader.Config config = Bdx.shaderProvider.config;
+		if (lightType.equals(Type.POINT))
+			return config.numPointLights;
+		else if (lightType.equals(Type.SUN))
+			return config.numDirectionalLights;
+		else
+			return config.numSpotLights;
+
 	}
 	
 }

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -258,7 +258,13 @@ public class Scene implements Named{
 				Light l = (Light)g;
 				l.energy(settings.getFloat("energy"));
 				l.color(new Vector4f(settings.get("color").asFloatArray()));
-				l.type = settings.getString("type");
+
+				if (settings.getString("type").equals("POINT"))
+					l.type = Light.Type.POINT;
+				else if (settings.getString("type").equals("SUN"))
+					l.type = Light.Type.SUN;
+				else if (settings.getString("type").equals("SPOT"))
+					l.type = Light.Type.SPOT;
 			}
 
 			g.name = gobj.name;


### PR DESCRIPTION
The BDXShaderProvider now, by default, supports 8 lights of each type.

The maximum light count of each kind can be altered with the static Light.setMaxCount() function. Also, Light.getMaxCount() allows you to get the number of lights BDX supports, currently. Note that using Light.setMaxCount() will require that the shaders be destroyed and recreated, using the deleteShaders() function below. When this happens, custom, already binded material ShaderPrograms will be destroyed and removed from the matShaders HashMap.

A Light's type is now an enum (called "Type") rather than a String, with three possible values: POINT, SUN, and SPOT.

Added deleteShaders() function to BDXShaderProvider to destroy existing shaders. LibGDX will then re-create new shaders when necessary.