### PR TITLE
(#506) Profiler changes/enhancements

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -276,9 +276,10 @@ public class Bdx{
 		}
 		mouse.wheelMove = 0;
 		
-		if (profiler.visible){
-			profiler.update();
-
+		profiler.updateVariables();
+		if (profiler.visible()){
+			profiler.updateVisible();
+			
 			// ------- Render profiler scene --------
 			
 			Scene profilerScene = profiler.scene;

--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -119,8 +119,9 @@ public class Bdx{
 		}
 
 	}
-
-	public static final float TICK_TIME = 1f/60f;
+	
+	public static final int TICK_RATE = 60;
+	public static final float TICK_TIME = 1f/TICK_RATE;
 	public static final int VERT_STRIDE = 8;
 	public static float time;
 	public static String firstScene;

--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -293,6 +293,9 @@ public class Bdx{
 			}
 			modelBatch.end();
 		}
+		if (profiler.gl.isEnabled()){
+			profiler.gl.updateFields();
+		}
 	}
 	
 	public static void dispose(){

--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -9,68 +9,79 @@ import java.util.Map.Entry;
 import com.badlogic.gdx.utils.TimeUtils;
 import com.badlogic.gdx.Gdx;
 
+import com.nilunder.bdx.Bdx;
 import com.nilunder.bdx.Scene;
-import com.nilunder.bdx.Text;
 import com.nilunder.bdx.GameObject;
+import com.nilunder.bdx.Text;
 
 import javax.vecmath.Vector3f;
+import javax.vecmath.Vector4f;
 
 
 public class Profiler extends LinkedHashMap<String, Long>{
 	
-	private final int TIC_RATE = 60;
+	private final int TICK_RATE = Bdx.TICK_RATE;
+	private final Vector3f SCREEN_SIZE = new Vector3f(448, 448, 1);
+	private final Vector4f BG_COLOR = new Vector4f(0.125f, 0.125f, 0.125f, 0.5f);
+	private final float SPACING = 0.6f;
+	private final float BAR_HEIGHT = 0.4f;
+	private final float BAR_WIDTH = SPACING * 4;
+	private final float BAR_POSITION = SPACING * 18;
+	private final float BG_WIDTH = SPACING * 23;
+	private final String EXC_MSG = "User created subsystem names should not start with: \"__\"";
+	
 	private LinkedHashMap<String, Long> startTimes;
 	private long totalStartTime;
 	private long lastStopTime;
 	private LinkedHashMap<String, Long> nanos;
 	private LinkedHashMap<String, Float> percents;
 	private ArrayList<String> names;
-	private ArrayList<Long> ticTimes;
+	private ArrayList<Long> tickTimes;
 	private GameObject display;
 	private GameObject background;
-	private Text ticInfo;
+	private Text tickInfo;
 	private LinkedHashMap<String, Text> texts;
 	private LinkedHashMap<String, GameObject> bars;
-	private Vector3f screenSize;
-	private float spacing;
-	private String exceptionMessage;
 	private boolean initialized;
 
-	public float avgTicRate;
-	public float avgTicTime;
+	public float avgTickRate;
+	public float avgTickTime;
 	public boolean visible;
 	public Scene scene;
 
 	public void init(boolean framerateProfile){
-		if (initialized) return;
+		if (initialized){
+			return;
+		}
 		visible = framerateProfile;
 		startTimes = new LinkedHashMap<String, Long>();
 		totalStartTime = TimeUtils.nanoTime();
 		nanos = new LinkedHashMap<String, Long>();
 		percents = new LinkedHashMap<String, Float>();
-		avgTicRate = TIC_RATE;
-		avgTicTime = 1000 / TIC_RATE;
-		exceptionMessage = "User created subsystem names should not start with: \"__\"";
+		avgTickRate = TICK_RATE;
+		avgTickTime = 1000 / TICK_RATE;
 		initialized = true;
-		if (visible) show();
+		if (visible){
+			show();
+		}
 	}
 
 	private void show(){
-		screenSize = new Vector3f(448, 448, 1);
-		spacing = 0.6f;
 		names = new ArrayList<String>();
-		ticTimes = new ArrayList<Long>();
-		for (int i = 0; i < TIC_RATE; i++) ticTimes.add(1000000000L / TIC_RATE);
+		tickTimes = new ArrayList<Long>();
+		for (int i=0; i < TICK_RATE; i++){
+			tickTimes.add(1000000000L / TICK_RATE);
+		}
 		texts = new LinkedHashMap<String, Text>();
 		bars = new LinkedHashMap<String, GameObject>();
 		scene = new Scene("__Profiler");
 		scene.init();
 		display = scene.add("__PDisplay");
 		background = display.children.get(0);
-		background.color(0.125f, 0.125f, 0.125f, 0.5f);
-		ticInfo = (Text)scene.add("__PText");
-		ticInfo.position(spacing, -spacing * 1.5f, 0);
-		ticInfo.parent(display);
+		background.color(BG_COLOR);
+		tickInfo = (Text)scene.add("__PText");
+		tickInfo.position(SPACING, -SPACING * 1.5f, 0);
+		tickInfo.parent(display);
 	}
 	
 	public void start(String name){
@@ -83,7 +94,9 @@ public class Profiler extends LinkedHashMap<String, Long>{
 		long deltaTime = stopTime - startTime;
 		if (visible){
 			long storedDeltaTime = deltaTime;
-			if (containsKey(name)) storedDeltaTime += get(name);
+			if (containsKey(name)){
+				storedDeltaTime += get(name);
+			}
 			put(name, storedDeltaTime);
 			lastStopTime = stopTime;
 		}
@@ -91,7 +104,9 @@ public class Profiler extends LinkedHashMap<String, Long>{
 	}
 	
 	public void remove(String name){
-		if (name.startsWith("__")) throw new RuntimeException(exceptionMessage);
+		if (name.startsWith("__")){
+			throw new RuntimeException(EXC_MSG);
+		}
 		startTimes.remove(name);
 		nanos.remove(name);
 		percents.remove(name);
@@ -101,60 +116,63 @@ public class Profiler extends LinkedHashMap<String, Long>{
 			texts.get(name).end();
 			bars.get(name).end();
 			int size = names.size();
-			float offset = names.get(size - 1).startsWith("__") ? spacing * 3f : spacing * 3.5f;
-			Vector3f backgroundScale = new Vector3f(spacing * 23, spacing * size + offset, 1);
+			float offset = names.get(size - 1).startsWith("__") ? SPACING * 3f : SPACING * 3.5f;
+			Vector3f backgroundScale = new Vector3f(BG_WIDTH, SPACING * size + offset, 1);
 			background.scale(backgroundScale.mul(display.scale()));
 		}
 	}
 	
-	private void updateAvgTicVars(long delta){
-		ticTimes.remove(0);
-		ticTimes.add(delta);
-		long sumTicTimes = 0;
-		for (long l : ticTimes) sumTicTimes += l;
-		avgTicTime = 1000000000000f / (TIC_RATE * sumTicTimes);
-		avgTicRate = TIC_RATE * 1000000000f / sumTicTimes;
+	private void updateVariables(long delta){
+		tickTimes.remove(0);
+		tickTimes.add(delta);
+		long sumTickTimes = 0;
+		for (long l : tickTimes){
+			sumTickTimes += l;
+		}
+		avgTickTime = 1000000000000f / (TICK_RATE * sumTickTimes);
+		avgTickRate = TICK_RATE * 1000000000f / sumTickTimes;
 	}
 
 	private void updateDisplay(){
-		ticInfo.set(formatForDisplay("tic info", avgTicTime, "ms", avgTicRate, "fps"));
+		tickInfo.set(formatForDisplay("tick info", avgTickTime, "ms", avgTickRate, "fps"));
 		for (String name : nanos.keySet()){
 			if (!names.contains(name)){
 				names.add(name);
 				int i = names.indexOf(name);
-				float offset = (name.startsWith("__")) ? spacing * 3 : spacing * 3.5f;
-				Vector3f position = new Vector3f(spacing, -(spacing * i + offset), 0);
+				float offset = (name.startsWith("__")) ? SPACING * 3 : SPACING * 3.5f;
+				Vector3f position = new Vector3f(SPACING, -(SPACING * i + offset), 0);
 				Vector3f displayScale = display.scale();
 				Text text = (Text)scene.add("__PText");
 				text.scale(displayScale);
 				text.position(position.mul(displayScale));
 				text.parent(display);
 				texts.put(name, text);
-				position.x = spacing * 18;
+				position.x = BAR_POSITION;
 				GameObject bar = scene.add("__PBar");
 				bar.scale(displayScale);
 				bar.position(position.mul(displayScale));
 				bar.parent(display);
 				bars.put(name, bar);
-				Vector3f backgroundScale = new Vector3f(spacing * 23, spacing * (i + 1) + offset, 1);
+				Vector3f backgroundScale = new Vector3f(BG_WIDTH, SPACING * (i + 1) + offset, 1);
 				background.scale(backgroundScale.mul(displayScale));
 			}
 			String n = name.startsWith("__") ? name.split("__")[1] : name;
 			float m = nanos.get(name) * 0.000001f;
 			float p = percents.get(name);
-			Vector3f barScale = new Vector3f(0.04f * spacing * p, 0.4f, 1);
+			Vector3f barScale = new Vector3f(BAR_WIDTH * p * 0.01f, BAR_HEIGHT, 1);
 			bars.get(name).scale(barScale.mul(display.scale()));
 			texts.get(name).set(formatForDisplay(n, m, "ms", p, "%"));
 		}
 		Vector3f currScreenSize = new Vector3f(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), 1);
-		if (!screenSize.equals(currScreenSize))
-			display.scale(screenSize.div(currScreenSize));
+		if (!SCREEN_SIZE.equals(currScreenSize)){
+			display.scale(SCREEN_SIZE.div(currScreenSize));
+		}
 	}
 	
 	public void update(){
 		long totalEndTime = TimeUtils.nanoTime();
 		long totalDeltaTime = totalEndTime - totalStartTime;
-		updateAvgTicVars(totalDeltaTime);
+		updateVariables(totalDeltaTime);
 		totalStartTime = totalEndTime;
 		long deltaTimes = 0;
 		LinkedHashMap<String, Long> userNanos = new LinkedHashMap<String, Long>();
@@ -183,54 +201,52 @@ public class Profiler extends LinkedHashMap<String, Long>{
 		updateDisplay();
 	}
 	
-	private static String formatForDisplay(String name, float avgTicTime, String timeUnits, float avgTicRate, String valueUnits) {
+	private static String formatForDisplay(String name, float avgTickTime, String timeUnits, float avgTickRate, String valueUnits){
 		// "%-14s %4.1f %-3s %4.1f %s"
 		StringBuffer buffer = new StringBuffer();
 		
-		addStringWithCharacterPadding(buffer, name, 14, false, ' ');
+		addString(buffer, name, 14, false, ' ');
 		buffer.append(" ");
-		addFloat(buffer, avgTicTime, 4, 1, ' ');
+		addFloat(buffer, avgTickTime, 4, 1, ' ');
 		buffer.append(" ");
-		addStringWithCharacterPadding(buffer, timeUnits, 3, false, ' ');
+		addString(buffer, timeUnits, 3, false, ' ');
 		buffer.append(" ");
-		addFloat(buffer, avgTicRate, 4, 1, ' ');
+		addFloat(buffer, avgTickRate, 4, 1, ' ');
 		buffer.append(" ");
 		buffer.append(valueUnits);
 		
 		return buffer.toString();
 	}
 	
-	private static void addFloat(StringBuffer buffer, float value, int fieldPadding, int fractionPadding, char character) {
+	private static void addFloat(StringBuffer buffer, float value, int fieldPadding, int fractionPadding, char character){
 		String converted = Float.toString(value);
 		String [] split = converted.split("\\.");
 		
-		addStringWithCharacterPadding(buffer, split.length > 0 ? split[0] : "0", fieldPadding - (fractionPadding + 1), true, character);
-		if (fractionPadding > 0) {
+		addString(buffer, split.length > 0 ? split[0] : "0", fieldPadding - (fractionPadding + 1), true, character);
+		if (fractionPadding > 0){
 			buffer.append(".");
-			addStringWithCharacterPadding(buffer, split.length > 1 ? split[1] : "0", fractionPadding, false, '0');	
+			addString(buffer, split.length > 1 ? split[1] : "0", fractionPadding, false, '0');	
 		}
 	}
 	
-	private static void addStringWithCharacterPadding(StringBuffer buffer, String value, int padding, boolean padLeft, char character) {
-		if (value != null) {
-			if (value.length() > padding) {
+	private static void addString(StringBuffer buffer, String value, int padding, boolean padLeft, char character){
+		if (value != null){
+			if (value.length() > padding){
 				buffer.append(value.substring(0, padding));
-			} else {
-				if (padLeft) {
-					padWithCharacter(buffer, padding - value.length(), character);
-					buffer.append(value);
-				} else {
-					buffer.append(value);
-					padWithCharacter(buffer, padding - value.length(), character);
-				}
+			}else if (padLeft){
+				padWithCharacter(buffer, padding - value.length(), character);
+				buffer.append(value);
+			}else{
+				buffer.append(value);
+				padWithCharacter(buffer, padding - value.length(), character);
 			}
-		} else {
+		}else{
 			padWithCharacter(buffer, padding, character);
 		}
 	}
 	
-	private static void padWithCharacter(StringBuffer buffer, int padding, char character) {
-		for (int i = 0; i < padding; i++) {
+	private static void padWithCharacter(StringBuffer buffer, int padding, char character){
+		for (int i=0; i < padding; i++){
 			buffer.append(character);
 		}
 	}

--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -14,6 +14,7 @@ import com.nilunder.bdx.Scene;
 import com.nilunder.bdx.GameObject;
 import com.nilunder.bdx.Text;
 
+import javax.vecmath.Vector2f;
 import javax.vecmath.Vector3f;
 import javax.vecmath.Vector4f;
 
@@ -29,6 +30,7 @@ public class Profiler extends LinkedHashMap<String, Long>{
 	private final float BAR_POSITION = SPACING * 18;
 	private final float BG_WIDTH = SPACING * 23;
 	private final String EXC_MSG = "User created subsystem names should not start with: \"__\"";
+	private final String ERR_MSG = "warning: \"Show Framerate and Profile\" is not enabled";
 	
 	private LinkedHashMap<String, Long> startTimes;
 	private long totalStartTime;
@@ -42,13 +44,19 @@ public class Profiler extends LinkedHashMap<String, Long>{
 	private Text tickInfo;
 	private LinkedHashMap<String, Text> texts;
 	private LinkedHashMap<String, GameObject> bars;
+	private float scale;
 	private boolean initialized;
-
+	private Vector2f lastDisplaySize;
+	
 	public float avgTickRate;
 	public float avgTickTime;
 	public boolean visible;
 	public Scene scene;
-
+	
+	{
+		scale = 1f;
+	}
+	
 	public void init(boolean framerateProfile){
 		if (initialized){
 			return;
@@ -67,6 +75,7 @@ public class Profiler extends LinkedHashMap<String, Long>{
 	}
 
 	private void show(){
+		lastDisplaySize = Bdx.display.size();
 		names = new ArrayList<String>();
 		tickTimes = new ArrayList<Long>();
 		for (int i=0; i < TICK_RATE; i++){
@@ -82,6 +91,20 @@ public class Profiler extends LinkedHashMap<String, Long>{
 		tickInfo = (Text)scene.add("__PText");
 		tickInfo.position(SPACING, -SPACING * 1.5f, 0);
 		tickInfo.parent(display);
+		updateScale();
+	}
+	
+	private void updateScale(){
+		display.scale(SCREEN_SIZE.div(new Vector3f(lastDisplaySize.x, lastDisplaySize.y, 1)).mul(scale));
+	}
+	
+	public void scale(float f){
+		if (!visible){
+			System.err.println(ERR_MSG);
+			return;
+		}
+		scale = f;
+		updateScale();
 	}
 	
 	public void start(String name){
@@ -163,9 +186,11 @@ public class Profiler extends LinkedHashMap<String, Long>{
 			bars.get(name).scale(barScale.mul(display.scale()));
 			texts.get(name).set(formatForDisplay(n, m, "ms", p, "%"));
 		}
-		Vector3f currScreenSize = new Vector3f(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), 1);
-		if (!SCREEN_SIZE.equals(currScreenSize)){
-			display.scale(SCREEN_SIZE.div(currScreenSize));
+		
+		Vector2f ds = Bdx.display.size();
+		if (!lastDisplaySize.equals(ds)){
+			lastDisplaySize = ds;
+			updateScale();
 		}
 	}
 	

--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -4,8 +4,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map.Entry;
 
-import com.badlogic.gdx.utils.TimeUtils;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.utils.TimeUtils;
+import com.badlogic.gdx.graphics.profiling.GLErrorListener;
 
 import com.nilunder.bdx.Bdx;
 import com.nilunder.bdx.Scene;
@@ -18,6 +19,103 @@ import javax.vecmath.Vector4f;
 
 
 public class Profiler{
+	
+	public class Gl extends com.badlogic.gdx.graphics.profiling.GLProfiler{
+		
+		private HashMap<String, Text> texts;
+		private HashMap<String, Integer> stats;
+		private HashMap<String, Integer> fields;
+		private String[] names;
+		
+		{
+			names = new String[]{
+				"calls",
+				"drawCalls",
+				"shaderSwitches",
+				"textureBindings",
+				"vertexCount"
+			};
+			
+			stats = new HashMap<String, Integer>();
+			fields = new HashMap<String, Integer>();
+			for (String name : names){
+				stats.put(name, 0);
+				fields.put(name, 0);
+			}
+		}
+		
+		protected void initTexts(){
+			texts = new HashMap<String, Text>();
+			Vector3f position = new Vector3f(SPACING, verticalOffset, 0);
+			for (String name : names){
+				texts.put(name, (Text)add("__PText", position));
+				position.y = verticalOffset(1);
+			}
+			texts.put("triangleCount", (Text)add("__PText", position));
+			verticalOffset(1.5f);
+		}
+		
+		public int calls(){
+			return stats.get("calls");
+		}
+		
+		public int drawCalls(){
+			return stats.get("drawCalls");
+		}
+		
+		public int shaderSwitches(){
+			return stats.get("shaderSwitches");
+		}
+		
+		public int textureBindings(){
+			return stats.get("textureBindings");
+		}
+		
+		public int vertexCount(){
+			return stats.get("vertexCount");
+		}
+		
+		public int triangleCount(){
+			return vertexCount() / 3;
+		}
+		
+		public void print(){
+			StringBuffer buffer = new StringBuffer("\n");
+			buffer.append(formatForGl("gl calls", calls()) + "\n");
+			buffer.append(formatForGl("gl draw calls", drawCalls()) + "\n");
+			buffer.append(formatForGl("gl shader switches", shaderSwitches()) + "\n");
+			buffer.append(formatForGl("gl texture bindings", textureBindings()) + "\n");
+			buffer.append(formatForGl("gl vertex count", vertexCount()) + "\n");
+			buffer.append(formatForGl("gl triangle count", triangleCount()) + "\n");
+			System.out.println(buffer.toString());
+		}
+		
+		protected void updateTexts(){
+			texts.get("calls").set(formatForGl("gl calls", calls()));
+			texts.get("drawCalls").set(formatForGl("gl draw calls", drawCalls()));
+			texts.get("shaderSwitches").set(formatForGl("gl shader switches", shaderSwitches()));
+			texts.get("textureBindings").set(formatForGl("gl texture bindings", textureBindings()));
+			texts.get("vertexCount").set(formatForGl("gl vertex count", vertexCount()));
+			texts.get("triangleCount").set(formatForGl("gl triangle count", triangleCount()));
+		}
+		
+		protected void updateStats(){
+			stats.put("calls", calls - fields.get("calls"));
+			stats.put("drawCalls", drawCalls - fields.get("drawCalls"));
+			stats.put("shaderSwitches", shaderSwitches - fields.get("shaderSwitches"));
+			stats.put("textureBindings", textureBindings - fields.get("textureBindings"));
+			stats.put("vertexCount", (int)vertexCount.total - fields.get("vertexCount"));
+		}
+		
+		public void updateFields(){
+			fields.put("calls", calls);
+			fields.put("drawCalls", drawCalls);
+			fields.put("shaderSwitches", shaderSwitches);
+			fields.put("textureBindings", textureBindings);
+			fields.put("vertexCount", (int)vertexCount.total);
+		}
+		
+	}
 	
 	private final int TICK_RATE = Bdx.TICK_RATE;
 	private final Vector3f SCREEN_SIZE = new Vector3f(448, 448, 1);
@@ -46,6 +144,8 @@ public class Profiler{
 	
 	private float scale;
 	private boolean visible;
+	private boolean subsystemsVisible;
+	private boolean glVisible;
 	private boolean initialized;
 	private Vector2f lastDisplaySize;
 	private float verticalOffset;
@@ -54,6 +154,7 @@ public class Profiler{
 	
 	public float avgTickRate;
 	public float avgTickTime;
+	public Gl gl;
 	
 	{
 		totalStartTime = TimeUtils.nanoTime();
@@ -70,6 +171,14 @@ public class Profiler{
 		initialized = false;
 		avgTickRate = TICK_RATE;
 		avgTickTime = 1000 / TICK_RATE;
+		
+		subsystemsVisible = true;
+		glVisible = false;
+		
+		scene = null;
+
+		gl = new Gl();
+		gl.listener = GLErrorListener.THROWING_LISTENER;
 	}
 	
 	private float verticalOffset(float factor){
@@ -77,9 +186,38 @@ public class Profiler{
 		return verticalOffset;
 	}
 	
+	private void addTextAndBar(String name){
+		Vector3f position = new Vector3f(SPACING, verticalOffset, 0);
+		texts.put(name, (Text)add("__PText", position));
+		position.x = BAR_POSITION;
+		bars.put(name, add("__PBar", position));
+	}
+	
 	private void scaleBackground(){
-		Vector3f sc = new Vector3f(BG_WIDTH, verticalOffset, 1);
+		Vector3f sc = new Vector3f(BG_WIDTH, verticalOffset + SPACING * 0.5f, 1);
 		display.children.get("__PBackground").scale(sc.mul(display.scale()));
+	}
+	
+	private void initSubsystems(){
+		String[] names = {
+			"__graphics",
+			"__input",
+			"__logic",
+			"__visuals",
+			"__camera",
+			"__worldstep",
+			"__children",
+			"__collisions",
+			"__render",
+			"__outside",
+		};
+		texts = new HashMap<String, Text>();
+		bars = new HashMap<String, GameObject>();
+		for (String name : names){
+			addTextAndBar(name);
+			verticalOffset(1);
+		}
+		verticalOffset(0.5f);
 	}
 	
 	public void init(boolean framerateProfile){
@@ -93,41 +231,32 @@ public class Profiler{
 		if (visible){
 			lastDisplaySize = Bdx.display.size();
 			
-			scene = new Scene("__Profiler");
-			scene.init();
+			if (scene == null){
+				scene = new Scene("__Profiler");
+				scene.init();
+				
+				display = scene.add("__PDisplay");
+				GameObject background = display.children.get("__PBackground");
+				background.color(BG_COLOR);
+				background.parent(display);
+				
+				verticalOffset(1.5f);
+				tickInfo = (Text)add("__PText", new Vector3f(SPACING, verticalOffset, 0));
+				verticalOffset(1.5f);
+				
+				updateScale();
+			}
 			
-			display = scene.add("__PDisplay");
-			GameObject background = display.children.get("__PBackground");
-			background.color(BG_COLOR);
-			background.parent(display);
+			if (glVisible){
+				gl.enable();
+				gl.initTexts();
+			}
 			
-			texts = new HashMap<String, Text>();
-			bars = new HashMap<String, GameObject>();
-			
-			verticalOffset(1.5f);
-			tickInfo = (Text)add("__PText", new Vector3f(SPACING, verticalOffset, 0));
-			verticalOffset(1.5f);
-			
-			String[] names = {
-				"__graphics",
-				"__input",
-				"__logic",
-				"__visuals",
-				"__camera",
-				"__worldstep",
-				"__children",
-				"__collisions",
-				"__render",
-				"__outside",
-			};
-			
-			for (String name : names){
-				addTextAndBar(name);
-				verticalOffset(1);
+			if (subsystemsVisible){
+				initSubsystems();
 			}
 			
 			scaleBackground();
-			updateScale();
 		}
 	}
 	
@@ -135,29 +264,50 @@ public class Profiler{
 		return visible;
 	}
 	
-	private void updateScale(){
-		display.scale(SCREEN_SIZE.div(new Vector3f(lastDisplaySize.x, lastDisplaySize.y, 1)).mul(scale));
+	private void reinitialize(){
+		if (scene != null){
+			texts.clear();
+			bars.clear();
+			scene.end();
+			scene = null;
+		}
+		initialized = false;
 	}
-	
-	public void scale(float f){
-		if (!visible){
+		
+	public void subsystemsVisible(boolean visible){
+		if (!this.visible){
 			System.err.println(ERR_MSG);
 			return;
 		}
-		scale = f;
-		updateScale();
+		if (subsystemsVisible == visible){
+			return;
+		}
+		subsystemsVisible = visible;
+		reinitialize();
+	}
+	
+	public void glVisible(boolean visible){
+		if (!this.visible){
+			System.err.println(ERR_MSG);
+			return;
+		}
+		if (glVisible == visible){
+			return;
+		}
+		glVisible = visible;
+		reinitialize();
 	}
 	
 	public void start(String name){
 		startTimes.put(name, TimeUtils.nanoTime());
 	}
-
+	
 	public float stop(String name){
 		long stopTime = TimeUtils.nanoTime();
 		long startTime = startTimes.containsKey(name) ? startTimes.get(name) : lastStopTime;
 		long deltaTime = stopTime - startTime;
 		
-		if (visible){
+		if (subsystemsVisible){
 			long storedDeltaTime = deltaTime;
 			if (deltaTimes.containsKey(name)){
 				storedDeltaTime += deltaTimes.get(name);
@@ -177,7 +327,7 @@ public class Profiler{
 		nanos.remove(name);
 		percents.remove(name);
 		
-		if (visible){
+		if (visible && subsystemsVisible){
 			texts.get(name).end();
 			texts.remove(name);
 			bars.get(name).end();
@@ -185,6 +335,19 @@ public class Profiler{
 			verticalOffset(-1);
 			scaleBackground();
 		}
+	}
+	
+	private void updateScale(){
+		display.scale(SCREEN_SIZE.div(new Vector3f(lastDisplaySize.x, lastDisplaySize.y, 1)).mul(scale));
+	}
+	
+	public void scale(float f){
+		if (!visible){
+			System.err.println(ERR_MSG);
+			return;
+		}
+		scale = f;
+		updateScale();
 	}
 	
 	public void updateVariables(){
@@ -199,8 +362,12 @@ public class Profiler{
 		}
 		avgTickTime = 1000000000000f / (TICK_RATE * sumTickTimes);
 		avgTickRate = TICK_RATE * 1000000000f / sumTickTimes;
+		
+		if (gl.isEnabled()){
+			gl.updateStats();
+		}
 	}
-
+	
 	private GameObject add(String name, Vector3f position){
 		GameObject obj = scene.add(name);
 		Vector3f scale = display.scale();
@@ -210,14 +377,32 @@ public class Profiler{
 		return obj;
 	}
 	
-	private void addTextAndBar(String name){
-		Vector3f position = new Vector3f(SPACING, verticalOffset, 0);
-		texts.put(name, (Text)add("__PText", position));
-		position.x = BAR_POSITION;
-		bars.put(name, add("__PBar", position));
-	}
-	
-	private void updateTextsAndBars(){
+	private void updateSubsystems(){
+		long sumDeltaTimes = 0;
+		HashMap<String, Long> userNanos = new HashMap<String, Long>();
+		HashMap<String, Float> userPercents = new HashMap<String, Float>();
+		for (Entry<String, Long> e : deltaTimes.entrySet()){
+			long deltaTime = e.getValue();
+			String name = e.getKey();
+			float deltaTimePercent = 100f * deltaTime / totalDeltaTime;
+			if (name.startsWith("__")){
+				sumDeltaTimes += deltaTime;
+				percents.put(name, deltaTimePercent);
+				nanos.put(name, deltaTime);
+			}else{
+				userPercents.put(name, deltaTimePercent);
+				userNanos.put(name, deltaTime);
+			}
+		}
+		long outsideDeltaTime = totalDeltaTime - sumDeltaTimes;
+		float outsideTimePercent = 100f * outsideDeltaTime / totalDeltaTime;
+		nanos.put("__outside", outsideDeltaTime);
+		percents.put("__outside", outsideTimePercent);
+		nanos.putAll(userNanos);
+		percents.putAll(userPercents);
+		startTimes.clear();
+		deltaTimes.clear();
+		
 		for (String name : nanos.keySet()){
 			if (!texts.containsKey(name)){
 				addTextAndBar(name);
@@ -229,30 +414,24 @@ public class Profiler{
 			float p = percents.get(name);
 			Vector3f barScale = new Vector3f(BAR_WIDTH * p * 0.01f, BAR_HEIGHT, 1);
 			bars.get(name).scale(barScale.mul(display.scale()));
-			texts.get(name).set(formatForDisplay(n, m, "ms", p, "%"));
+			texts.get(name).set(formatForSubsystems(n, m, "ms", p, "%"));
 		}
 	}
 	
 	public void updateVisible(){
-		tickInfo.set(formatForDisplay("tick info", avgTickTime, "ms", avgTickRate, "fps"));
-		
-		long sumDeltaTimes = 0;
-		for (Entry<String, Long> e : deltaTimes.entrySet()){
-			long deltaTime = e.getValue();
-			String name = e.getKey();
-			percents.put(name, 100f * deltaTime / totalDeltaTime);
-			nanos.put(name, deltaTime);
-			if (name.startsWith("__")){
-				sumDeltaTimes += deltaTime;
-			}
+		if (!initialized){
+			init(true);
 		}
-		long outsideDeltaTime = totalDeltaTime - sumDeltaTimes;
-		float outsideTimePercent = 100f * outsideDeltaTime / totalDeltaTime;
-		nanos.put("__outside", outsideDeltaTime);
-		percents.put("__outside", outsideTimePercent);
-		startTimes.clear();
-		deltaTimes.clear();
-		updateTextsAndBars();
+		
+		tickInfo.set(formatForSubsystems("tick info", avgTickTime, "ms", avgTickRate, "fps"));
+
+		if (subsystemsVisible){
+			updateSubsystems();
+		}
+		
+		if (glVisible){
+			gl.updateTexts();
+		}
 		
 		Vector2f ds = Bdx.display.size();
 		if (!lastDisplaySize.equals(ds)){
@@ -261,7 +440,16 @@ public class Profiler{
 		}
 	}
 	
-	private static String formatForDisplay(String name, float avgTickTime, String timeUnits, float avgTickRate, String valueUnits){
+	private static String formatForGl(String name, int value){
+		// "%-21s %7f"
+		StringBuffer buffer = new StringBuffer();
+		addString(buffer, name, 21, false, ' ');
+		buffer.append(" ");
+		addInt(buffer, value, 7, ' ');
+		return buffer.toString();
+	}
+	
+	private static String formatForSubsystems(String name, float avgTickTime, String timeUnits, float avgTickRate, String valueUnits){
 		// "%-14s %4.1f %-3s %4.1f %s"
 		StringBuffer buffer = new StringBuffer();
 		
@@ -276,6 +464,10 @@ public class Profiler{
 		buffer.append(valueUnits);
 		
 		return buffer.toString();
+	}
+	
+	private static void addInt(StringBuffer buffer, int value, int fieldPadding, char character){
+		addString(buffer, Integer.toString(value), fieldPadding - 1, true, character);
 	}
 	
 	private static void addFloat(StringBuffer buffer, float value, int fieldPadding, int fractionPadding, char character){


### PR DESCRIPTION
Here's a ```Sacky.java``` to test with:
```java
import com.nilunder.bdx.*;

public class Sacky extends GameObject{
	
	private boolean test;
	private int caseIndex;
	
	public void init(){
		test = true;
		caseIndex = 0;
	}
	
	public void main(){
		if (test){
			Bdx.profiler.start("Test");
		}
		
		if (Bdx.mouse.btnHit("left")){
			if (caseIndex == 3){
				caseIndex = 0;
			}else{
				caseIndex += 1;
			}
		}
		if (caseIndex == 0){
			Bdx.profiler.subsystemsVisible(false);
		}else if (caseIndex == 1){
			Bdx.profiler.glVisible(true);
		}else if (caseIndex == 2){
			Bdx.profiler.subsystemsVisible(true);
		}else if (caseIndex == 3){
			Bdx.profiler.glVisible(false);
		}
		
        if (Bdx.keyboard.keyHit("t")){
			System.out.println(Bdx.profiler.avgTickRate);
        }else if (Bdx.keyboard.keyHit("e")){
			if (!Bdx.profiler.gl.isEnabled()){
				Bdx.profiler.gl.enable();
			}
        }else if (Bdx.keyboard.keyHit("d")){
			System.out.println(Bdx.profiler.gl.drawCalls());
        }else if (Bdx.keyboard.keyHit("p")){
			Bdx.profiler.gl.print();
        }else if (Bdx.keyboard.keyHit("space")){
			applyForce(0, 0, 300);
		}
		
        if (test){
			Bdx.profiler.stop("test");
			if (Bdx.keyboard.keyHit("enter")){
				Bdx.profiler.remove("test");
				test = false;
			}
		}else if (Bdx.keyboard.keyHit("enter")){
			test = true;
		}
	}
	
}
```
___

## API Bdx

<a name="profiler" href="#profiler">#</a> **profiler** - [Profiler](https://github.com/GoranM/bdx/wiki/API-Profiler)

BDX profiler. Show by enabling "Show Framerate and Profile" in Blender (in Game Info or Display panel of Render Properties).
___

## API Profiler

This class measures and displays info about the average tick rate and tick time, execution times for various subsystems and GL statistics.

User created subsystems can be timed and are displayed beneath internal subsystems. When subsystems and the GL profiler are set to invisible, only the tick info will remain visible.

<a name="gl" href="#gl">#</a> **gl** - Gl

Extends [GLProfiler](https://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/graphics/profiling/GLProfiler.html). Calculates and shows various GL statistics: the number of calls, draw calls, shader switches, texture bindings, vertex count and triangle count.

By default the GL profiler is not visible, and so disabled. Setting to visible will automatically enable the GL profiler, but setting to invisible will not disable it.

If the BDX profiler is not visible, statistics are only updated if the GL profiler is enabled.
___

<a name="scale" href="#scale">#</a> **scale**(float f)

Sets the scale.

<a name="subsystemsVisible" href="#subsystemsVisible">#</a> **subsystemsVisible**(boolean visible)

Sets visibility of subsystems.

<a name="glVisible" href="#glVisible">#</a> **glVisible**(boolean visible)

Sets visibility of the GL profiler.

<a name="start" href="#start">#</a> **start**(String name)

Stores the start time in nanoseconds of a subsystem.

<a name="stop" href="#stop">#</a> **stop**(String name) - Float

Returns the delta time of a subsystem between start and current time in milliseconds. Possible to time subsystems directly after each other without having to store the start times.

Example:
```java
Bdx.profiler.start("a");
float a = Bdx.profiler.stop("a");
float b = Bdx.profiler.stop("b");
```
<a name="remove" href="#remove">#</a> **remove**(String name)

Removes execution time. Use with adding and removing objects.

Example:
```java
public class BossA extends GameObject{

	public void main(){
		Bdx.profiler.start("BossA");
		// code
		Bdx.profiler.stop("BossA");
	}
	
	public void onEnd(){
		Bdx.profiler.remove("BossA");
	}
	
}
```
___

## API Gl

Extends [GLProfiler](https://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/graphics/profiling/GLProfiler.html). When enabled, collects statistics about GL calls and checks for GL errors.

<a name="listener" href="#listener">#</a> **listener** - [GLErrorListener](https://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/graphics/profiling/GLErrorListener.html)

By default the GL listener will throw a GdxRuntimeException with error name.

___

<a name="enable" href="#enable">#</a> **enable**()

Enables collecting and updating of GL statistics, and GL error listener.

<a name="disable" href="#disable">#</a> **disable**()

Disables collecting and updating of GL statistics, and GL error listener.

<a name="reset" href="#reset">#</a> **reset**()

Resets GL statistics.

<a name="print" href="#print">#</a> **print**()

Prints GL statistics.

<a name="calls" href="#calls">#</a> **calls**() - int

<a name="drawCalls" href="#drawCalls">#</a> **drawCalls**() - int

<a name="shaderSwitches" href="#shaderSwitches">#</a> **shaderSwitches**() - int

<a name="textureBindings" href="#textureBindings">#</a> **textureBindings**() - int

<a name="vertexCount" href="#vertexCount">#</a> **vertexCount**() - int

<a name="triangleCount" href="#triangleCount">#</a> **triangleCount**() - int
