### PR TITLE
(#518) Recreate gamepads after display changes.

### DIFF
--- a/src/com/nilunder/bdx/inputs/GdxProcessor.java
+++ b/src/com/nilunder/bdx/inputs/GdxProcessor.java
@@ -21,7 +21,7 @@ public static class UpDownLog{
 	
 }
 
-private static class GamepadAdapter extends ControllerAdapter{
+public static class GamepadAdapter extends ControllerAdapter{
 
 	private Gamepad gamepad;
 	private Integer[] lastPressedHats;
@@ -158,12 +158,6 @@ private static class GamepadAdapter extends ControllerAdapter{
 		this.keyboard = keyboard;
 		this.mouse = mouse;
 		this.allocatedFingers = allocatedFingers;
-
-		for (Gamepad g : gamepads){
-			if (g.controller != null)
-				g.controller.addListener(new GamepadAdapter(g));
-		}
-
 	}
 
 	public boolean keyDown(int code){


### PR DESCRIPTION
The timer's necessary because this should only be done once the display is completely finished changing; if it's too early, the newly created gamepads won't be recognized. This creates a 1-second delay between changing the window's size or fullscreen status, and the gamepad responding to input.