### PR TITLE
Vector2f.length(f) & Vector2f.mul(v) & Vector2f.div(v)

### DIFF
--- a/extern/gwt-vecmath/src/javax/vecmath/Vector2f.java
+++ b/extern/gwt-vecmath/src/javax/vecmath/Vector2f.java
@@ -199,6 +199,8 @@ public class Vector2f extends Tuple2f implements java.io.Serializable {
    }
 
    public final void length(float n){
+	   if (length() == 0)
+		   return;
 	   normalize();
 	   scale(n);
    }
@@ -214,6 +216,20 @@ public class Vector2f extends Tuple2f implements java.io.Serializable {
 	   v.x *= n;
 	   v.y *= n;
 	   return v;
+   }
+   
+   public final Vector2f mul(Vector2f b){
+	   Vector2f a = new Vector2f(this);
+	   a.x *= b.x;
+	   a.y *= b.y;
+	   return a;
+   }
+
+   public final Vector2f div(Vector2f b){
+	   Vector2f a = new Vector2f(this);
+	   a.x /= b.x;
+	   a.y /= b.y;
+	   return a;
    }
    
    public final Vector2f reflected(Vector2f normal){


### PR DESCRIPTION
```Vector2f``` had some BDX conveniences added to it, but aren't exposed to the API yet. As I'm at it I add a change and a few additions too so ```Vector2f``` has the same features as ```Vector3f```.