### PR TITLE
xray(includeAll=false, group, mask)

### DIFF
--- a/src/com/nilunder/bdx/inputs/Pointer.java
+++ b/src/com/nilunder/bdx/inputs/Pointer.java
@@ -83,6 +83,11 @@ abstract class Pointer {
 		
 	}
 	
+	public ArrayList<RayHit> xray(short group, short mask) {
+		return xray(false, group, mask);
+		
+	}
+	
 	public ArrayList<RayHit> xray(){
 		return xray(false, (short)~0, (short)~0);
 	}


### PR DESCRIPTION
```Pointer.xray()```methods weren't exposed to the API yet. As I'm at it I'm adding a method so the methods match up with the methods in ```Scene```.