### PR TITLE
(#581) Custom Material Shaders fix.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -9,11 +9,7 @@ import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.g2d.*;
 import com.badlogic.gdx.graphics.g3d.*;
 import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
-import com.badlogic.gdx.graphics.g3d.utils.DepthShaderProvider;
-import com.nilunder.bdx.gl.BDXDepthShaderProvider;
-import com.nilunder.bdx.gl.BDXShaderProvider;
-import com.nilunder.bdx.gl.RenderBuffer;
-import com.nilunder.bdx.gl.ShaderProgram;
+import com.nilunder.bdx.gl.*;
 import com.nilunder.bdx.inputs.*;
 import com.nilunder.bdx.audio.*;
 import com.nilunder.bdx.utils.*;
@@ -157,7 +153,7 @@ public class Bdx{
 	public static Keyboard keyboard;
 	public static ArrayList<Finger> fingers;
 	public static ArrayList<Component> components;
-	public static HashMap<String, ShaderProgram> matShaders;
+	public static HashMap<String, MaterialShader> matShaders;
 	public static BDXShaderProvider shaderProvider;
 
 	private static boolean advancedLightingOn;
@@ -185,7 +181,7 @@ public class Bdx{
 		keyboard = new Keyboard();
 		fingers = new ArrayList<Finger>(); 
 		components = new ArrayList<Component>();
-		matShaders = new HashMap<String, ShaderProgram>();
+		matShaders = new HashMap<String, MaterialShader>();
 
 		allocatedFingers = new ArrayList<Finger>();
 		for (int i = 0; i < 10; ++i){
@@ -258,7 +254,7 @@ public class Bdx{
 
 			// ------- Render Scene --------
 
-			if (scene.filters.size() > 0){
+			if (scene.screenShaders.size() > 0){
 				frameBuffer.begin();
 				Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 			}
@@ -274,13 +270,13 @@ public class Bdx{
 
 			scene.executeDrawCommands();
 
-			if (scene.filters.size() > 0){
+			if (scene.screenShaders.size() > 0){
 
 				frameBuffer.end();
 
 				boolean usingDepth = false;
 
-				for (ShaderProgram filter : scene.filters) {
+				for (ScreenShader filter : scene.screenShaders) {
 					if (filter.usingDepthTexture())
 						usingDepth = true;
 				}
@@ -305,7 +301,7 @@ public class Bdx{
 
 				Gdx.gl.glClearColor(0, 0, 0, 1);
 
-				for (ShaderProgram filter : scene.filters) {
+				for (ScreenShader filter : scene.screenShaders) {
 					
 					filter.begin();
 					filter.setUniformf("time", Bdx.time);
@@ -381,7 +377,7 @@ public class Bdx{
 		tempBuffer.dispose();
 		depthBuffer.dispose();
 		shaderProvider.dispose();
-		for (ShaderProgram s : Bdx.matShaders.values()) {
+		for (MaterialShader s : Bdx.matShaders.values()) {
 			s.dispose();
 		}
 	}

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -40,7 +40,7 @@ import com.bulletphysics.dynamics.constraintsolver.SequentialImpulseConstraintSo
 import com.bulletphysics.linearmath.Transform;
 import com.nilunder.bdx.gl.Material;
 import com.nilunder.bdx.gl.RenderBuffer;
-import com.nilunder.bdx.gl.ShaderProgram;
+import com.nilunder.bdx.gl.ScreenShader;
 import com.nilunder.bdx.utils.*;
 import com.nilunder.bdx.inputs.*;
 import com.nilunder.bdx.components.*;
@@ -76,7 +76,7 @@ public class Scene implements Named{
 	private Instantiator instantiator;
 	
 	public HashMap<String, GameObject> templates;
-	public ArrayList<ShaderProgram> filters;
+	public ArrayList<ScreenShader> screenShaders;
 	public RenderBuffer lastFrameBuffer;
 	public Environment environment;
 	static private ShapeRenderer shapeRenderer;
@@ -150,7 +150,7 @@ public class Scene implements Named{
 		environment.set(new SpotLightsAttribute());
 		environment.set(new DirectionalLightsAttribute());
 				
-		filters = new ArrayList<ShaderProgram>();
+		screenShaders = new ArrayList<ScreenShader>();
 		defaultMaterial = new Material("__BDX_DEFAULT");
 		defaultMaterial.set(new ColorAttribute(ColorAttribute.AmbientLight, 1, 1, 1, 1));
 		defaultMaterial.set(new ColorAttribute(ColorAttribute.Diffuse, 1, 1, 1, 1));
@@ -389,7 +389,7 @@ public class Scene implements Named{
 		for (Texture t : textures.values()){
 			t.dispose();
 		}
-		for (ShaderProgram s : filters) {
+		for (ScreenShader s : screenShaders) {
 			s.dispose();
 		}
 	}

--- a/src/com/nilunder/bdx/gl/BDXShaderProvider.java
+++ b/src/com/nilunder/bdx/gl/BDXShaderProvider.java
@@ -26,8 +26,11 @@ class BDXDefaultShader extends DefaultShader {
 		super(renderable, config);
 	}
 
-	public BDXDefaultShader(Renderable renderable, DefaultShader.Config config, ShaderProgram shaderProgram) {
-		super(renderable, config, shaderProgram);
+	public BDXDefaultShader(Renderable renderable, DefaultShader.Config config, MaterialShader shaderProgram) {
+		super(renderable,
+				config,
+				shaderProgram.set(createPrefix(renderable, config) + shaderProgram.vertexShader,
+						createPrefix(renderable, config) + shaderProgram.fragmentShader).compile().programData);
 	}
 
 	public void render(Renderable renderable, Attributes combinedAttributes)
@@ -72,7 +75,7 @@ class BDXDefaultShader extends DefaultShader {
 
 		if (hasCustomShader) {
 
-			if (Bdx.matShaders.get(matName) == program)					// Is this shader for that rendered material?
+			if (Bdx.matShaders.get(matName).programData == program)					// Is this shader for that rendered material?
 				return true;											// If so, it can be used to render
 			else
 				return false;
@@ -106,7 +109,7 @@ public class BDXShaderProvider extends DefaultShaderProvider {
 		BDXDefaultShader shader;
 
 		if (Bdx.matShaders.containsKey(renderable.material.id)) {
-			ShaderProgram sp = Bdx.matShaders.get(renderable.material.id);
+			MaterialShader sp = Bdx.matShaders.get(renderable.material.id);
 			shader = new BDXDefaultShader(renderable, config, sp);
 			shader.materialName = renderable.material.id;
 		}

--- a/src/com/nilunder/bdx/gl/MaterialShader.java
+++ b/src/com/nilunder/bdx/gl/MaterialShader.java
@@ -1,0 +1,53 @@
+package com.nilunder.bdx.gl;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.utils.Disposable;
+
+public class MaterialShader implements Disposable{
+
+	public String vertexShader;
+	public String fragmentShader;
+	public com.badlogic.gdx.graphics.glutils.ShaderProgram programData;
+
+	public MaterialShader(String vertexShader, String fragmentShader) {
+		set(vertexShader, fragmentShader);
+	}
+
+	public MaterialShader(FileHandle vertexShader, FileHandle fragmentShader) {
+		this(vertexShader.readString(), fragmentShader.readString());
+	}
+
+	public MaterialShader set(String vertexShader, String fragmentShader) {
+		this.vertexShader = vertexShader;
+		this.fragmentShader = fragmentShader;
+		return this;
+	}
+
+	public static MaterialShader load(String vertexPath, String fragmentPath) {
+		return new MaterialShader(Gdx.files.internal(vertexPath), Gdx.files.internal(fragmentPath));
+	}
+
+	public MaterialShader compile(){
+
+		if (programData != null)
+			programData.dispose();
+
+		programData = new ShaderProgram(vertexShader, fragmentShader);
+
+		if (!programData.isCompiled())
+			throw new RuntimeException("Shader compilation error: " + programData.getLog());
+
+		return this;
+	}
+
+	public boolean compiled(){
+		return programData != null;
+	}
+
+	public void dispose(){
+		programData.dispose();
+	}
+
+}

--- a/src/com/nilunder/bdx/gl/RenderBuffer.java
+++ b/src/com/nilunder/bdx/gl/RenderBuffer.java
@@ -24,9 +24,9 @@ public class RenderBuffer extends FrameBuffer{
 		this(batch, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());		
 	}
 	
-	public void drawTo(RenderBuffer dest,ShaderProgram filter){
+	public void drawTo(RenderBuffer dest,ScreenShader filter){
 
-		if (ShaderProgram.nearestFiltering) {
+		if (ScreenShader.nearestFiltering) {
 			if (dest != null)
 				dest.getColorBufferTexture().setFilter(Texture.TextureFilter.Nearest, Texture.TextureFilter.Nearest);
 		}

--- a/src/com/nilunder/bdx/gl/ScreenShader.java
+++ b/src/com/nilunder/bdx/gl/ScreenShader.java
@@ -5,7 +5,7 @@ import javax.vecmath.Vector2f;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 
-public class ShaderProgram extends com.badlogic.gdx.graphics.glutils.ShaderProgram {
+public class ScreenShader extends com.badlogic.gdx.graphics.glutils.ShaderProgram {
 
 	public Vector2f renderScale;
 	public boolean overlay;
@@ -13,23 +13,22 @@ public class ShaderProgram extends com.badlogic.gdx.graphics.glutils.ShaderProgr
 	private boolean usingDepthTexture = false;
 	private boolean checkedShaderProgram = false;
 	
-	public ShaderProgram(String vertexShader, String fragmentShader) {
+	public ScreenShader(String vertexShader, String fragmentShader) {
 
 		super(vertexShader, fragmentShader);
 
-		if (!isCompiled()) {
+		if (!isCompiled())
 			throw new RuntimeException("Shader compilation error: " + getLog());
-		}
 		
 		renderScale = new Vector2f(1, 1);
 		overlay = false;
 	}
-	public ShaderProgram(FileHandle vertexShader, FileHandle fragmentShader) {
+	public ScreenShader(FileHandle vertexShader, FileHandle fragmentShader) {
 		this(vertexShader.readString(), fragmentShader.readString());
 	}
 	
-	public static ShaderProgram load(String vertexPath, String fragmentPath) {
-		return new ShaderProgram(Gdx.files.internal(vertexPath), Gdx.files.internal(fragmentPath));
+	public static ScreenShader load(String vertexPath, String fragmentPath) {
+		return new ScreenShader(Gdx.files.internal(vertexPath), Gdx.files.internal(fragmentPath));
 	}
 
 	public boolean usingDepthTexture(){


### PR DESCRIPTION
Adding MaterialShader and renaming ShaderProgram to ScreenShader.
Calling ArrayListMaterials.unique() will rename cloned materials to try to keep them unique.