### PR TITLE
MaterialShader only disposes its programData if it's not null.

### DIFF
--- a/src/com/nilunder/bdx/gl/MaterialShader.java
+++ b/src/com/nilunder/bdx/gl/MaterialShader.java
@@ -47,7 +47,10 @@ public class MaterialShader implements Disposable{
 	}
 
 	public void dispose(){
-		programData.dispose();
+		if (programData != null) {
+			programData.dispose();
+			programData = null;
+		}
 	}
 
 }


### PR DESCRIPTION
Solves a crash on exiting BDX sometimes, or when restarting BDX quickly enough (it's trying to dispose the ShaderProgram, though it had already been disposed).