### PR TITLE
GL clear color shouldn't have alpha before...

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -297,7 +297,7 @@ public class Bdx{
 				scene.lastFrameBuffer.getColorBufferTexture().bind(1);
 				Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0);
 
-				Gdx.gl.glClearColor(0, 0, 0, 1);
+				Gdx.gl.glClearColor(0, 0, 0, 0);
 
 				for (ScreenShader filter : scene.screenShaders) {
 					


### PR DESCRIPTION
... Rendering screen shaders.
This allows the ScreenShader.overlay field to work properly.
This bug was introduced shortly after the depth texture render commit.