### PR TITLE
Additional scene.xray() fix.

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -649,9 +649,9 @@ public class Scene implements Named{
 
 				Vector3f delta = ray.position.minus(startPos);
 
-				if (delta.length() == 0) {
+				if (delta.length() < 0.005f) {
 					delta = new Vector3f(dist);
-					delta.length(0.001f);
+					delta.length(0.005f);
 				}
 
 				startPos.add(delta);


### PR DESCRIPTION
Set delta to larger value if less than that value, not just if it's 0 (before, if delta was very close to 0, but not quite 0, it would "stall". This would cause a freeze while the xray process continued (which eventually resolved). It was noticeable if you used xray on objects that were flatly next to each other. 

Also bumping the delta amount from 0.001 to 0.01. That's accuracy to a hundredth of a BU, which is close enough to 0 while still (hopefully) being large enough to "push" the xray process through in case it's very close to 0. It should be enough to detect multiple objects fine, still.