### PR TITLE
(#635) - Render-to-texture and texture-switching.

### DIFF
--- a/src/com/nilunder/bdx/Camera.java
+++ b/src/com/nilunder/bdx/Camera.java
@@ -3,9 +3,11 @@ package com.nilunder.bdx;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector3;
 
 import com.bulletphysics.linearmath.Transform;
+import com.nilunder.bdx.gl.RenderBuffer;
 
 import javax.vecmath.Vector2f;
 import javax.vecmath.Vector3f;
@@ -20,7 +22,9 @@ public class Camera extends GameObject{
 	
 	public Type type;
 	public com.badlogic.gdx.graphics.Camera data;
-	
+	boolean renderingToTexture;
+	RenderBuffer renderBuffer;
+
 	public void initData(Type type){
 		this.type = type;
 		if (type == Type.PERSPECTIVE){
@@ -79,7 +83,7 @@ public class Camera extends GameObject{
 	public void fov(float fov){
 		((PerspectiveCamera)data).fieldOfView = (float)Math.toDegrees(fov);
 	}
-	
+
 	public float fov(){
 		Matrix4f p = projection();
 		float fov;
@@ -113,6 +117,13 @@ public class Camera extends GameObject{
 		axis = axis("Y");
 		data.up.set(axis.x, axis.y, axis.z);
 		data.update();
+	}
+
+	public TextureRegion texture(){
+		renderingToTexture = true;
+		if (renderBuffer == null)
+			renderBuffer = new RenderBuffer(null);
+		return renderBuffer.region;
 	}
 
 }

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -61,7 +61,7 @@ public class Scene implements Named{
 	private FileHandle scene;
 
 	public HashMap<String,Model> models;
-	private HashMap<String,Texture> textures;
+	public HashMap<String,Texture> textures;
 	public HashMap<String,Material> materials;
 	public Material defaultMaterial;
 	private Model defaultModel;
@@ -241,8 +241,8 @@ public class Scene implements Named{
 					texture = new Texture(Gdx.files.internal("bdx/textures/" + texName));
 					textures.put(texName, texture);
 				}
-				material.set(TextureAttribute.createDiffuse(texture));
 				texture.setWrap(TextureWrap.Repeat, TextureWrap.Repeat);
+				material.texture(texture);
 			}
 			
 			BlendingAttribute ba;
@@ -387,14 +387,21 @@ public class Scene implements Named{
 		lastFrameBuffer.dispose();
 		defaultModel.dispose();
 
-		for (Model m : models.values()){
+		for (Model m : models.values())
 			m.dispose();
-		}
-		for (Texture t : textures.values()){
+
+		for (Texture t : textures.values())
 			t.dispose();
-		}
-		for (ScreenShader s : screenShaders) {
+
+		for (ScreenShader s : screenShaders)
 			s.dispose();
+
+		for (Camera c : cameras)
+			c.renderBuffer.dispose();
+
+		for (Material m : materials.values()) {
+			if (m.currentTexture != null)
+				m.currentTexture.dispose();
 		}
 	}
 	

--- a/src/com/nilunder/bdx/gl/Material.java
+++ b/src/com/nilunder/bdx/gl/Material.java
@@ -1,9 +1,13 @@
 package com.nilunder.bdx.gl;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.g3d.Attribute;
 import com.badlogic.gdx.graphics.g3d.attributes.BlendingAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute;
+import com.badlogic.gdx.graphics.g3d.attributes.TextureAttribute;
 import com.badlogic.gdx.utils.Array;
 import com.nilunder.bdx.Scene;
 import com.nilunder.bdx.utils.ArrayListNamed;
@@ -11,6 +15,8 @@ import com.nilunder.bdx.utils.Color;
 import com.nilunder.bdx.utils.Named;
 
 public class Material extends com.badlogic.gdx.graphics.g3d.Material implements Named {
+
+	public Texture currentTexture;
 
 	public Material() {
 		super();
@@ -99,6 +105,27 @@ public class Material extends com.badlogic.gdx.graphics.g3d.Material implements 
 
 	public String toString(){
 		return id + " <" + getClass().getName() + "> @" + Integer.toHexString(hashCode());
+	}
+
+	public Texture texture(String filename) {
+		Texture tex = new Texture(Gdx.files.internal(filename));
+		tex.setWrap(Texture.TextureWrap.Repeat, Texture.TextureWrap.Repeat);
+		texture(tex);
+		return tex;
+	}
+
+	public void texture(Texture tex) {
+		if (currentTexture != tex) {		// Only switch texture if it's not already pointing to the texture
+			currentTexture = tex;
+			this.set(TextureAttribute.createDiffuse(tex));
+		}
+	}
+
+	public void texture(TextureRegion texRegion) {
+		if (currentTexture != texRegion.getTexture()) {		// Only switch texture if it's not already pointing to the texture
+			currentTexture = texRegion.getTexture();
+			this.set(TextureAttribute.createDiffuse(texRegion));
+		}
 	}
 
 }

--- a/src/com/nilunder/bdx/gl/RenderBuffer.java
+++ b/src/com/nilunder/bdx/gl/RenderBuffer.java
@@ -11,7 +11,7 @@ import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 public class RenderBuffer extends FrameBuffer{
 		
 	private SpriteBatch batch;
-	private TextureRegion region;
+	public TextureRegion region;
 		
 	public RenderBuffer(SpriteBatch batch, int bufferWidth, int bufferHeight) {
 		super(Pixmap.Format.RGBA8888, bufferWidth, bufferHeight, true);


### PR DESCRIPTION
Material.texture() added to switch the texture attribute present on the material. The material will only switch textures if it's not the one that's currently equipped on the material. The new Material.texture() function works with Textures and TextureRegions (so that TextureRegions returned from camera.texture() can be properly flipped).
Model rendering code from Bdx.java moved into renderWorld() function.
Scene.textures HashMap is now public to allow switching between textures mid-game.