### PR TITLE
Bug-fix for the Camera's new renderbuffer.

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -396,8 +396,10 @@ public class Scene implements Named{
 		for (ScreenShader s : screenShaders)
 			s.dispose();
 
-		for (Camera c : cameras)
-			c.renderBuffer.dispose();
+		for (Camera c : cameras) {
+			if (c.renderBuffer != null)
+				c.renderBuffer.dispose();
+		}
 
 		for (Material m : materials.values()) {
 			if (m.currentTexture != null)


### PR DESCRIPTION
Only dispose() camera's renderBuffers if they've been actually created.