### PR TITLE
Render-to-texture improvements / fixes.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -255,7 +255,7 @@ public class Bdx{
 			renderWorld(modelBatch, scene, scene.camera);			// Render main view
 
 			for (Camera cam : scene.cameras){
-				if (cam.renderingToTexture) {
+				if (cam.renderingToTexture && cam.renderBuffer != null) {
 					cam.renderBuffer.begin();
 					Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT);
 					Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
@@ -407,7 +407,7 @@ public class Bdx{
 			for (Camera cam : scene.cameras) {                // Have to do this, as the RenderBuffers need to be resized for the new window size
 				if (cam.renderBuffer != null)
 					cam.renderBuffer.dispose();
-				cam.renderBuffer = new RenderBuffer(null);
+				cam.renderBuffer = null;
 			}
 
 			if (scene.lastFrameBuffer != null)

--- a/src/com/nilunder/bdx/Camera.java
+++ b/src/com/nilunder/bdx/Camera.java
@@ -22,8 +22,8 @@ public class Camera extends GameObject{
 	
 	public Type type;
 	public com.badlogic.gdx.graphics.Camera data;
-	boolean renderingToTexture;
-	RenderBuffer renderBuffer;
+	public boolean renderingToTexture;
+	public RenderBuffer renderBuffer;
 
 	public void initData(Type type){
 		this.type = type;
@@ -65,7 +65,7 @@ public class Camera extends GameObject{
   	}
 	
 	public void width(float w){
-		data.viewportWidth = w;
+		data.viewportWidth = Math.max(w, 1);		// A width of 0 crashes BDX
 	}
 	
 	public float width(){
@@ -73,7 +73,7 @@ public class Camera extends GameObject{
 	}
 	
 	public void height(float h){
-		data.viewportHeight = h;
+		data.viewportHeight = Math.max(h, 1);
 	}
 	
 	public float height(){
@@ -117,13 +117,21 @@ public class Camera extends GameObject{
 		axis = axis("Y");
 		data.up.set(axis.x, axis.y, axis.z);
 		data.update();
+
+		if (renderingToTexture) {
+			if (renderBuffer == null || ((int) width() != renderBuffer.getWidth() || (int) height() != renderBuffer.getHeight())) {
+				if (renderBuffer != null)
+					renderBuffer.dispose();
+				renderBuffer = new RenderBuffer(null, (int) width(), (int) height());
+			}
+		}
 	}
 
 	public TextureRegion texture(){
-		renderingToTexture = true;
-		if (renderBuffer == null)
-			renderBuffer = new RenderBuffer(null);
-		return renderBuffer.region;
+		TextureRegion r = null;
+		if (renderBuffer != null)
+			r = renderBuffer.region;
+		return r;
 	}
 
 }

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -868,7 +868,10 @@ public class Scene implements Named{
 			Bdx.profiler.stop("__logic");
 
 			updateVisuals();
-			camera.update();
+			for (Camera cam : cameras) {
+				if (cam == camera || cam.renderingToTexture)		// Update camera if it's the main scene camera, or if it's rendering to texture
+					cam.update();
+			}
 			Bdx.profiler.stop("__scene");
 
 			try{


### PR DESCRIPTION
Camera.width() and Camera.height() now can't be set below 1, to avoid crashes.

Camera rendering-to-texture is now toggled via the Camera.renderingToTexture boolean.

Camera RenderBuffer size is tied to Camera.width() and Camera.height().

Scene.update updates all active cameras (the main camera, and the ones that are rendering-to-texture).