### PR TITLE
Minor fixes.

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -606,8 +606,10 @@ public class GameObject implements Named{
 		onEnd();
 		parent(null);
 		valid = false;
-		if (uniqueModel != null)
+		if (uniqueModel != null) {
 			uniqueModel.dispose();
+			uniqueModel = null;
+		}
 		scene.remove(this);
 		for (GameObject g : touchingObjects)
 			g.activate();
@@ -821,6 +823,9 @@ public class GameObject implements Named{
 			visible = false;
 			return;
 		}
+
+		if (joinedMeshObjects.contains(this))
+			throw new RuntimeException("ERROR: " + name() + ".joinedMeshObjects cannot contain a reference to itself.");
 		
 		// Join the transformed vertex arrays
 		
@@ -888,6 +893,10 @@ public class GameObject implements Named{
 		for (short i=0; i < numIndices; i++){
 			mpb.index(i);
 		}
+
+		if (uniqueModel != null)
+			uniqueModel.dispose();
+
 		uniqueModel = builder.end();
 		modelInstance = new ModelInstance(uniqueModel);
 		mesh = new com.nilunder.bdx.gl.Mesh(modelInstance.model);

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -88,6 +88,7 @@ public class Scene implements Named{
 	private float fogDepth;
 	private boolean fogOn;
 	private boolean valid;
+	private boolean requestedEnd;
 
 	public Scene(String name){
 		this(Gdx.files.internal("bdx/scenes/" + name + ".bdx"), instantiators.get(name));
@@ -144,6 +145,7 @@ public class Scene implements Named{
 
 	public void init(){
 		requestedRestart = false;
+		requestedEnd = false;
 		paused = false;
 
 		if (shapeRenderer == null)
@@ -798,6 +800,7 @@ public class Scene implements Named{
 	}
 	
 	private void runObjectLogic(){
+
 		if (requestedRestart){
 			for (GameObject g : objects){
 				g.endNoChildren();
@@ -838,6 +841,25 @@ public class Scene implements Named{
 		}
 
 		toBeRemoved.clear();
+
+		if (requestedEnd) {
+			valid = false;
+
+			for (GameObject g : objects)
+				g.end();
+
+			dispose();
+
+			if (Bdx.scenes.contains(this)) {
+
+				if (Bdx.scenes.size() > 1)
+					Bdx.scenes.remove(this);
+				else
+					Bdx.end();
+
+			}
+
+		}
 
 	}
 	
@@ -892,23 +914,7 @@ public class Scene implements Named{
 	}
 
 	public void end(){
-
-		valid = false;
-
-		for (GameObject g : objects)
-			g.end();
-
-		dispose();
-
-		if (Bdx.scenes.contains(this)) {
-
-			if (Bdx.scenes.size() > 1)
-				Bdx.scenes.remove(this);
-			else
-				Bdx.end();
-
-		}
-
+		requestedEnd = true;
 	}
 
 	public String toString(){


### PR DESCRIPTION
-Don't restart immediately when calling Bdx.restart(). Previously, BDX would crash if restart() was called quicker than the game could properly initialize OpenGL and render a frame.
-Don't continue to render a scene if it's no longer valid and has been ended. This was a problem, as ending the game scene would dispose of models and textures, but BDX would still try to render it.
-Don't end the scene immediately when calling scene.end(). It's best not to dispose of data (like meshes) in the middle of updating object logic.
-GameObject.uniqueModel is set to null when it's disposed of, for safety.
-End scenes when Bdx.dispose() is called (and so when Bdx.end() is called).
-In GameObject.updateJoinedMesh(), dispose GameObject.uniqueModel if it hasn't been disposed of previously before assigning to it.
-Throw an exception if you add an object to its own joinedMeshObjects list and try to update the mesh.