### PR TITLE
Bug-fix for Timer.

### DIFF
--- a/src/com/nilunder/bdx/utils/Timer.java
+++ b/src/com/nilunder/bdx/utils/Timer.java
@@ -25,8 +25,9 @@ public class Timer {
 	}
 
 	public float time(){
-		if (paused) return delta;
-		return Bdx.time - timeLast;
+		float f = Bdx.time - timeLast;
+		if (paused) f = delta;
+		return Math.round(f * 10000.0f) / 10000.0f;
 	}
 
 	public float timeLeft(){
@@ -55,7 +56,7 @@ public class Timer {
 	}
 
 	public boolean done(){
-		return time() > interval;
+		return time() >= interval;
 	}
 
 	public void done(boolean done){


### PR DESCRIPTION
Round off Timer for floating point mathematics inaccuracy.
Have done() be greater or equal to the value of the interval.

_____

So basically, the Timer class is a bit off - due to math on floating point numbers and the done() function returning true only if `time() > interval`, sometimes it will go off a frame late. You can observe this when looking at the Timer's timeLeft() function and counting the number of times it triggers before the Timer's tick() function goes off. (It triggers 61 times for a full second, right?)

This probably wouldn't be much of an issue during normal gameplay, but with the new logicFrequency addition, it's possible for an object that only runs once per second to be delayed a full second if looking at a Timer (because it doesn't go off every frame the object is running). 

Note that this causes SpriteAnim to not work with 0 FPS animations, which is... fine, I guess? People should just set the frame on a 1 FPS animation if they need to do it like that.