### PR TITLE
Fix so that BDX doesn't remove MaterialShaders if shaders are deleted.

### DIFF
--- a/src/com/nilunder/bdx/gl/BDXShaderProvider.java
+++ b/src/com/nilunder/bdx/gl/BDXShaderProvider.java
@@ -30,11 +30,10 @@ class BDXDefaultShader extends DefaultShader {
 		super(renderable, config);
 	}
 
-	public BDXDefaultShader(Renderable renderable, DefaultShader.Config config, MaterialShader shaderProgram) {
+	public BDXDefaultShader(Renderable renderable, DefaultShader.Config config, MaterialShader materialShader) {
 		super(renderable,
 				config,
-				shaderProgram.set(createPrefix(renderable, config) + shaderProgram.vertexShader,
-						createPrefix(renderable, config) + shaderProgram.fragmentShader).compile().programData);
+				materialShader.setPrefix(createPrefix(renderable, config)).compile().programData);
 	}
 
 	public void render(Renderable renderable, Attributes combinedAttributes)
@@ -87,11 +86,9 @@ class BDXDefaultShader extends DefaultShader {
 
 		String matName = renderable.material.id;
 
-		boolean hasCustomShader = Bdx.matShaders.containsKey(matName);	// Is there a custom shader for the rendered material?
+		if (Bdx.matShaders.containsKey(matName)) {						// Is there a custom shader for the rendered material?
 
-		if (hasCustomShader) {
-
-			if (Bdx.matShaders.get(matName).programData == program)					// Is this shader for that rendered material?
+			if (Bdx.matShaders.get(matName).programData == program)	    // Is this shader for that rendered material?
 				return true;											// If so, it can be used to render
 			else
 				return false;
@@ -157,8 +154,9 @@ public class BDXShaderProvider extends DefaultShaderProvider {
 		for (Shader s : shaders){
 			BDXDefaultShader shader = (BDXDefaultShader) s;
 			if (shader.materialName != null)
-				Bdx.matShaders.remove(shader.materialName);		// Remove the ShaderProgram from the custom Shaders HashMap because
-			s.dispose();										// Shader.dispose() destroys the ShaderProgram, too.
+				Bdx.matShaders.get(shader.materialName).dispose();	// "Empty" the MaterialShader; it'll be recompiled when necessary, so no need to remove it
+			else
+				s.dispose();
 		}
 		shaders.clear();
 	}

--- a/src/com/nilunder/bdx/gl/MaterialShader.java
+++ b/src/com/nilunder/bdx/gl/MaterialShader.java
@@ -9,20 +9,17 @@ public class MaterialShader implements Disposable{
 
 	public String vertexShader;
 	public String fragmentShader;
+	private String prefix;
+
 	public com.badlogic.gdx.graphics.glutils.ShaderProgram programData;
 
 	public MaterialShader(String vertexShader, String fragmentShader) {
-		set(vertexShader, fragmentShader);
+		this.vertexShader = vertexShader;
+		this.fragmentShader = fragmentShader;
 	}
 
 	public MaterialShader(FileHandle vertexShader, FileHandle fragmentShader) {
 		this(vertexShader.readString(), fragmentShader.readString());
-	}
-
-	public MaterialShader set(String vertexShader, String fragmentShader) {
-		this.vertexShader = vertexShader;
-		this.fragmentShader = fragmentShader;
-		return this;
 	}
 
 	public static MaterialShader load(String vertexPath, String fragmentPath) {
@@ -31,10 +28,9 @@ public class MaterialShader implements Disposable{
 
 	public MaterialShader compile(){
 
-		if (programData != null)
-			programData.dispose();
+		dispose();
 
-		programData = new ShaderProgram(vertexShader, fragmentShader);
+		programData = new ShaderProgram(prefix + vertexShader, prefix + fragmentShader);
 
 		if (!programData.isCompiled())
 			throw new RuntimeException("Shader compilation error: " + programData.getLog());
@@ -47,10 +43,15 @@ public class MaterialShader implements Disposable{
 	}
 
 	public void dispose(){
-		if (programData != null) {
+		if (compiled()) {
 			programData.dispose();
 			programData = null;
 		}
+	}
+
+	public MaterialShader setPrefix(String prefix){
+		this.prefix = prefix;
+		return this;
 	}
 
 }


### PR DESCRIPTION
Changes:
- MaterialShader.setPrefix() added so BDXShaderProvider doesn't have to tack the prefixes onto the vertex and fragment shaders directly. Rather, the prefix is added when compile() is run, so that deleting the shader works (because otherwise, it adds the prefix on again).
- MaterialShader.set() is unnecessary, so it was removed.
- BDXShaderProvider.deleteShaders() now only disposes of the program data in the MaterialShader, rather than removing the entire thing.