### PR TITLE
Bug: error with inactive Camera's

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -372,14 +372,11 @@ public class Scene implements Named{
 
 		hookParentChild();
 		
+		cameras = new ArrayList<Camera>();
+		
 		addInstances();
 		
-		cameras = new ArrayList<Camera>();
-		String[] cameraNames = json.get("cameras").asStringArray();
-		for (String cn : cameraNames)
-			cameras.add((Camera) objects.get(cn));
-		
-		camera = cameras.get(0);
+		camera = (Camera) objects.get(json.get("cameras").asStringArray()[0]);
 
 		for (GameObject g : sortByPriority(new ArrayList<GameObject>(objects))){
 			initGameObject(g);
@@ -488,6 +485,7 @@ public class Scene implements Named{
 			c.near(cobj.near());
 			c.far(cobj.far());
 			c.update();
+			cameras.add(c);
 		}else if (g instanceof Text){
 			Text t = (Text)g;
 			Text tt = (Text)gobj;


### PR DESCRIPTION
```java
Exception in thread "LWJGL Application" java.lang.NullPointerException
        at com.nilunder.bdx.Bdx.resize(Bdx.java:428)
        at com.raco.test.BdxApp.resize(BdxApp.java:34)
        at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:203)
        at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:124)
```
`Camera` is null when BDX resizes, because `Scene.init()` also adds inactive camera's to `cameras`.

Solution: add camera's to `Scene.cameras` when becoming active (when added to the scene).