### PR TITLE
(#691) Fix: AndroidLauncher.java package name

### DIFF
--- a/blender/bdx/ops/createproj.py
+++ b/blender/bdx/ops/createproj.py
@@ -187,7 +187,7 @@ class CreateBdxProject(bpy.types.Operator):
         sc_bdx = bpy.context.scene.bdx
 
         ut.set_file_line(gdx_al, 1,
-                         "package " + sc_bdx.java_pack + '.android;')
+                         "package " + sc_bdx.java_pack + ";")
 
         ut.set_file_line(gdx_al, 8,
                          "import " + sc_bdx.java_pack + ".BdxApp;")


### PR DESCRIPTION
Since [the LibGDX 1.9.2 update (27th of April)](https://github.com/GoranM/bdx/commit/c9166309fef09346494c74f5f42150a252427192) the `AndroidLauncher.java` class is not located in a separate folder, named `android`.