### PR TITLE
Bug-fix: xray() fix.

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -670,15 +670,15 @@ public class Scene implements Named{
 
 				}
 
-				Vector3f delta = ray.position.minus(startPos);
+				float delta = ray.position.minus(startPos).length();
 
-				if (delta.length() < 0.005f) {
-					delta = new Vector3f(dist);
-					delta.length(0.005f);
-				}
+				delta = Math.max(0.005f, delta);
 
-				startPos.add(delta);
-				dist.sub(delta);
+				Vector3f n = new Vector3f(vec);
+				n.length(delta);
+
+				startPos.add(n);
+				dist.sub(n);
 
 			}
 			else


### PR DESCRIPTION
Previously, the function created a vector from the ray's ending position to the starting position. If the ending position were somehow behind the starting position, this could cause an infinite loop (which did happen).
Now, just the distance is used, while the vector is created using the target direction vector (so the rays always head in the same direction).