### PR TITLE
Bug-fix: Don't remove bodies from worlds until after the main loop.

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -614,7 +614,6 @@ public class Scene implements Named{
 	
 	public void remove(GameObject g){
 		toBeAdded.remove(g);
-		world.removeRigidBody(g.body);
 		toBeRemoved.add(g);
 	}
 
@@ -844,6 +843,7 @@ public class Scene implements Named{
 		toBeAdded.clear();
 
 		for (GameObject g : toBeRemoved) {
+			world.removeRigidBody(g.body);
 			objects.remove(g);
 			if (g instanceof Light)
 				lights.remove(g);


### PR DESCRIPTION
This was causing a NPE error on removing touching static ghost objects (for me, one of them was a merged static object).