### PR TITLE
Bug-fix: Don't crash if an image type is defined without a filepath. Also...

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -562,7 +562,7 @@ def used_materials(objects):
 
 def srl_materials(materials):
     def texture_name(m):
-        if m.active_texture and hasattr(m.active_texture, "image"):
+        if m.active_texture and hasattr(m.active_texture, "image") and m.active_texture.image is not None:
             filepath = m.active_texture.image.filepath
             textures_dir = "textures"
             return filepath[filepath.find(textures_dir)+len(textures_dir)+1:]

--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -269,8 +269,6 @@ public class Bdx{
 				}
 			}
 
-			scene.executeDrawCommands();
-
 			if (scene.screenShaders.size() > 0){
 
 				frameBuffer.end();
@@ -334,6 +332,8 @@ public class Bdx{
 				scene.lastFrameBuffer.clear();
 				frameBuffer.drawTo(scene.lastFrameBuffer);
 			}
+
+			scene.executeDrawCommands();
 
 			display.clearColor(display.clearColor());
 


### PR DESCRIPTION
... Execute draw commands after Screen Shader block so they're visible on top.