### PR TITLE
(#741) - Move endNoChildren() higher in end().

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -609,10 +609,10 @@ public class GameObject implements Named{
 	}
 
 	public void end(){
+		endNoChildren();
 		for (GameObject g : new ArrayList<GameObject>(children)){
 			g.end();
 		}
-		endNoChildren();
 	}
 	
 	public void endNoChildren(){


### PR DESCRIPTION
Allows onEnd() to run before children are ended.