### PR TITLE
(#564) - Generic gamepad profile.

### DIFF
--- a/src/com/nilunder/bdx/inputs/Gamepad.java
+++ b/src/com/nilunder/bdx/inputs/Gamepad.java
@@ -216,6 +216,32 @@ public static class Profile{
 
 		profiles.put(p.name, p);
 
+		p = new Profile("Generic");
+
+		for (int a = 0; a < 32; a++)
+			p.btnToCode.put("b" + String.valueOf(a), a);
+
+		for (int a = 0; a < 16; a++) {
+			String axisName = "a" + String.valueOf(a);
+			Axis axis = new Axis(a);
+			p.axes.put(axisName, axis);
+			p.btnToCode.put(axisName + "-", -200 - axis.code);
+			p.btnToCode.put(axisName + "+", 200 + axis.code);
+		}
+		
+		for (int a = 0; a < 8; a++) {
+			Stick s = new Stick(p.axes.get("a" + String.valueOf(a * 2)),
+					p.axes.get("a" + String.valueOf(a * 2 + 1)));
+			p.sticks.put("s" + String.valueOf(a), s);
+		}
+
+		p.btnToCode.put("left", 100 + PovDirection.west.ordinal());
+		p.btnToCode.put("right", 100 + PovDirection.east.ordinal());
+		p.btnToCode.put("up", 100 + PovDirection.north.ordinal());
+		p.btnToCode.put("down", 100 + PovDirection.south.ordinal());
+
+		profiles.put(p.name, p);
+
 		profile("XBOX360"); // probably most common, so it's the default
 
 	}


### PR DESCRIPTION
Should work for practically any kind of gamepad, aside from the sticks, which are automatically set and may not match the actual gamepad's physical setup. The inputs are set as so:

`g:b0` - Button 0. Maximum of 32 buttons
`g:a0+ / g:a0-` Axis 0 + and - (up and down). Maximum of 16 axes.
`g:s0` - Stick 0. Maximum of 8 sticks.

The D-Pad is set up as usual.
______

The why of this is to allow people to use any gamepad with any button and axis configuration on their gamepad (so not just with specific profiles / gamepads). With the profile system as it is, if an input isn't recognized under the profile, it's ignored. This way, the profile itself (and the OS's handling of the profile) doesn't matter so much as just the ability to map input names to gamepad inputs, regardless of which they are.