### PR TITLE
(#770) - Remove parent after game logic update in frame.

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -619,7 +619,6 @@ public class GameObject implements Named{
 		if (!valid)
 			return;
 		onEnd();
-		parent(null);
 		valid = false;
 		if (uniqueModel != null) {
 			uniqueModel.dispose();

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -867,6 +867,7 @@ public class Scene implements Named{
 		toBeAdded.clear();
 
 		for (GameObject g : toBeRemoved) {
+			g.parent(null);
 			world.removeRigidBody(g.body);
 			objects.remove(g);
 			if (g instanceof Light)


### PR DESCRIPTION
Prevents children from being removed from GameObject immediately after end() is called.