### PR TITLE
(#680, #780) - Mesh refactoring.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -420,8 +420,10 @@ public class Bdx{
 			s.dispose();
 		for (RenderBuffer b : availableTempBuffers.values())
 			b.dispose();
-		for (Scene s : scenes)
-			s.end();
+		for (Scene s : scenes) {
+			s.dispose();
+		}
+
 	}
 
 	public static void end(){

--- a/src/com/nilunder/bdx/components/MeshAnim.java
+++ b/src/com/nilunder/bdx/components/MeshAnim.java
@@ -69,7 +69,7 @@ public class MeshAnim extends Component<GameObject> {
 		ticker = new Timer();
 		speed = 1;
 		state = play;
-		currentMesh = g.modelName();
+		currentMesh = g.mesh().name();
 	}
 
 	public void add(String name, String[] frames){
@@ -110,7 +110,7 @@ public class MeshAnim extends Component<GameObject> {
 
 		if (!currentMesh.equals(frame)) {
 			currentMesh = frame;
-			g.replaceModel(currentMesh);
+			g.mesh(currentMesh);
 		}
 	}
 

--- a/src/com/nilunder/bdx/components/SpriteAnim.java
+++ b/src/com/nilunder/bdx/components/SpriteAnim.java
@@ -73,7 +73,7 @@ public class SpriteAnim extends Component<GameObject> {
 	public SpriteAnim(GameObject g, int frameWidth, int frameHeight, boolean rowBased, boolean uniqueModel){
 		super(g);
 		if (uniqueModel)
-			g.useUniqueModel();
+			g.mesh(g.mesh().copy());
 		this.rowBased = rowBased;
 		animations = new HashMap<String, Animation>();
 		ticker = new Timer();

--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -369,8 +369,8 @@ public class Profiler{
 		
 		display = scene.add("__PDisplay");
 		background = display.children.get("__PBackground");
-		background.materials.color(BG_COLOR);
-		
+		background.mesh().materials.color(BG_COLOR);
+
 		scene.viewport.type(Viewport.Type.SCREEN);
 		updateViewport();
 		


### PR DESCRIPTION
- Materials are now part of the Mesh, and so are linked to the Mesh (so changing the color of a material on a mesh will change the color of the material on all instances of the same Mesh). To make a material copy, either assign a new Material(), or assign a new Mesh using Mesh.copy(). The default material is the exception to this rule - if an object has no material assigned to it in Blender, it will get its own copy of the defaultMaterial.

- Model disposal is now handled by the Mesh on finalize().

+ updateBody() function to update the physics mesh of a GameObject, either using the existing display mesh, or another mesh if one is provided.