### PR TITLE
(#792) - Fix playDir not being set on play() call.

### DIFF
--- a/src/com/nilunder/bdx/components/SpriteAnim.java
+++ b/src/com/nilunder/bdx/components/SpriteAnim.java
@@ -151,11 +151,13 @@ public class SpriteAnim extends Component<GameObject> {
 
 		if (active != next){
 			active = next;
+			active.playDir = speed * active.fps < 0 ? -1 : 1;
 			active.reset();
 			ticker.done(true); // immediate play
 		}
 
 		if (!active.looping && active.onLastFrame()){
+			active.playDir = speed * active.fps < 0 ? -1 : 1;
 			active.reset();
 			ticker.done(true);
 		}


### PR DESCRIPTION
\+ `play(animName, playSpeed)` function to assist in this.

Without setting speed before calling `play()`, this won't fix the issue (which is why the new `play(animName, playSpeed)` function is suggested, so people won't have to worry about the ordering).