### PR TITLE
Fix to reset animation on change for MeshAnim.

### DIFF
--- a/src/com/nilunder/bdx/components/MeshAnim.java
+++ b/src/com/nilunder/bdx/components/MeshAnim.java
@@ -93,10 +93,13 @@ public class MeshAnim extends Component<GameObject> {
 
 		if (active != next){
 			active = next;
+			active.playDir = speed * active.fps < 0 ? -1 : 1;
+			active.reset();
 			ticker.done(true); // immediate play
 		}
 
 		if (!active.looping && active.onLastFrame()){
+			active.playDir = speed * active.fps < 0 ? -1 : 1;
 			active.reset();
 			ticker.done(true);
 		}


### PR DESCRIPTION
Also fix to set playDir on play() call for MeshAnim (so these just apply the changes for SpriteAnim to MeshAnim).