### PR TITLE
(#789) - Move MaterialShader application to Materials.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -163,7 +163,6 @@ public class Bdx{
 	public static Keyboard keyboard;
 	public static ArrayList<Finger> fingers;
 	public static ArrayList<Component> components;
-	public static HashMap<String, MaterialShader> matShaders;
 	public static BDXShaderProvider shaderProvider;
 
 	private static boolean advancedLightingOn;
@@ -191,7 +190,6 @@ public class Bdx{
 		keyboard = new Keyboard();
 		fingers = new ArrayList<Finger>();
 		components = new ArrayList<Component>();
-		matShaders = new HashMap<String, MaterialShader>();
 
 		allocatedFingers = new ArrayList<Finger>();
 		for (int i = 0; i < 10; ++i){
@@ -416,8 +414,6 @@ public class Bdx{
 		Bdx.sounds.dispose();
 		Bdx.music.dispose();
 
-		for (MaterialShader s : Bdx.matShaders.values())
-			s.dispose();
 		for (RenderBuffer b : availableTempBuffers.values())
 			b.dispose();
 		for (Scene s : scenes) {

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -391,6 +391,9 @@ public class Scene implements Named{
 
 		valid = false;
 
+		for (GameObject g : objects)
+			g.end();
+
 		lastFrameBuffer.dispose();
 		defaultMesh = null;
 		meshes = null;
@@ -407,12 +410,10 @@ public class Scene implements Named{
 		}
 
 		for (Material m : materials.values()) {
+			if (m.shader != null)
+				m.shader.dispose();
 			if (m.currentTexture != null)
 				m.currentTexture.dispose();
-		}
-
-		for (GameObject g : objects) {
-			g.end();
 		}
 
 	}

--- a/src/com/nilunder/bdx/gl/Material.java
+++ b/src/com/nilunder/bdx/gl/Material.java
@@ -17,6 +17,7 @@ import com.nilunder.bdx.utils.Named;
 public class Material extends com.badlogic.gdx.graphics.g3d.Material implements Named {
 
 	public Texture currentTexture;
+	public MaterialShader shader;
 
 	public Material() {
 		super();
@@ -44,6 +45,7 @@ public class Material extends com.badlogic.gdx.graphics.g3d.Material implements 
 
 	public Material(Material copyFrom) {
 		super(copyFrom);
+		shader = copyFrom.shader;
 	}
 
 	public Material(com.badlogic.gdx.graphics.g3d.Material copyFrom){

--- a/src/com/nilunder/bdx/gl/MaterialShader.java
+++ b/src/com/nilunder/bdx/gl/MaterialShader.java
@@ -10,6 +10,7 @@ public class MaterialShader implements Disposable{
 	public String vertexShader;
 	public String fragmentShader;
 	private String prefix;
+	public boolean active = true;
 
 	public com.badlogic.gdx.graphics.glutils.ShaderProgram programData;
 

--- a/src/com/nilunder/bdx/gl/Mesh.java
+++ b/src/com/nilunder/bdx/gl/Mesh.java
@@ -228,7 +228,7 @@ public class Mesh implements Named {
 		newMesh.materials.clear();
 
 		for (NodePart part : uniqueModel.nodes.get(0).parts) {
-			Material newMat = new Material(part.material);
+			Material newMat = new Material( (Material) part.material );			// Don't forget to cast to Material for it to be a true copy (see shader copying)
 			newMesh.materials.add(newMat);
 			part.material = newMat;
 		}


### PR DESCRIPTION
\+ Now Materials have their own "shader" field that indicates how to render the material (null is the default shader).

\+ Added MaterialShader.active to easily activate and deactivate a MaterialShader.

\+ Mesh.copy() now applies the Material's shader to the duplicate (that way, they should be unique but identical, in a sense, after copying).

\+ As an added bug-fix, ending GameObjects earlier fixes crashes when adding GameObjects on scene end (due to Scene.meshes being cleared).