### PR TITLE
(#814): Replace "OutOfMemoryError" with "Error" to comply with GWT -

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -952,7 +952,7 @@ public class GameObject implements Named{
 					mpb.index(idx);
 					idx += 1;
 				}
-			}catch (OutOfMemoryError error){
+			}catch (Error error){
 				throw new RuntimeException("MODEL ERROR: Models with more than 32767 vertices are not supported. Decrease the number of objects to join.");
 			}
 		}

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -725,7 +725,7 @@ public class Scene implements Named{
 					mpb.index(idx);
 					idx += 1;
 				}
-			}catch (OutOfMemoryError e){
+			}catch (Error e){
 				throw new RuntimeException("MODEL ERROR: Models with more than 32767 vertices are not supported. " + model.name + " has " + Integer.toString(len) + " vertices.");
 			}
 		}


### PR DESCRIPTION
(HTML target).