### PR TITLE
Streamlining MaterialShader / ScreenShader loading

### DIFF
--- a/src/com/nilunder/bdx/gl/MaterialShader.java
+++ b/src/com/nilunder/bdx/gl/MaterialShader.java
@@ -24,7 +24,7 @@ public class MaterialShader implements Disposable{
 	}
 
 	public static MaterialShader load(String vertexPath, String fragmentPath) {
-		return new MaterialShader(Gdx.files.internal(vertexPath), Gdx.files.internal(fragmentPath));
+		return new MaterialShader(Gdx.files.internal("bdx/shaders/3d/" + vertexPath), Gdx.files.internal("bdx/shaders/3d/" + fragmentPath));
 	}
 
 	public MaterialShader compile(){

--- a/src/com/nilunder/bdx/gl/ScreenShader.java
+++ b/src/com/nilunder/bdx/gl/ScreenShader.java
@@ -29,7 +29,11 @@ public class ScreenShader extends com.badlogic.gdx.graphics.glutils.ShaderProgra
 	}
 	
 	public static ScreenShader load(String vertexPath, String fragmentPath) {
-		return new ScreenShader(Gdx.files.internal(vertexPath), Gdx.files.internal(fragmentPath));
+		return new ScreenShader(Gdx.files.internal("bdx/shaders/2d/" + vertexPath), Gdx.files.internal("bdx/shaders/2d/" + fragmentPath));
+	}
+
+	public static ScreenShader load(String fragmentPath) {
+		return load("default.vert", fragmentPath);
 	}
 
 	public boolean usingDepthTexture(){


### PR DESCRIPTION
+ScreenShader.load() function that only takes a fragment shader (as you generally never alter the vertices of the screen shader quad).
- ScreenShader.load() / MaterialShader.load() String-argument functions now default to shader directory.