### PR TITLE
Bug-fix: Setting Material.blendMode now sets blended to true.

### DIFF
--- a/src/com/nilunder/bdx/gl/Material.java
+++ b/src/com/nilunder/bdx/gl/Material.java
@@ -90,6 +90,7 @@ public class Material extends com.badlogic.gdx.graphics.g3d.Material implements 
 		BlendingAttribute ba = (BlendingAttribute) get(BlendingAttribute.Type);
 		ba.sourceFunction = src;
 		ba.destFunction = dest;
+		ba.blended = true;		// Has to be true for the blend mode to take effect
 	}
 
 	public boolean shadeless(){


### PR DESCRIPTION
Otherwise the blend mode won't show up when set, unless the material is set to transparent initially (in Blender).