### PR TITLE
Add on() functions for Lights.

### DIFF
--- a/src/com/nilunder/bdx/Light.java
+++ b/src/com/nilunder/bdx/Light.java
@@ -20,6 +20,7 @@ public class Light extends GameObject {
 	private Color color = new Color();
 	private float spotSize;
 	private float exponent = 1;
+	private boolean on;
 
 	public enum Type {
 		POINT,
@@ -109,6 +110,45 @@ public class Light extends GameObject {
 		super.transform(mat, updateLocal);
 		
 		updateLight();
+	}
+
+	public void on(boolean on){
+
+		this.on = on;
+
+		if (type == Type.POINT) {
+			PointLightsAttribute la = (PointLightsAttribute) scene.environment.get(PointLightsAttribute.Type);
+			PointLight pl = (PointLight) lightData;
+
+			if (on && !la.lights.contains(pl, true))
+				la.lights.add(pl);
+			else if (!on && la.lights.contains(pl, true))
+				la.lights.removeValue(pl, true);
+
+		} else if (type == Type.SUN) {
+			DirectionalLightsAttribute la = (DirectionalLightsAttribute) scene.environment.get(DirectionalLightsAttribute.Type);
+			DirectionalLight dl = (DirectionalLight) lightData;
+
+			if (on && !la.lights.contains(dl, true))
+				la.lights.add(dl);
+			else if (!on && la.lights.contains(dl, true))
+				la.lights.removeValue(dl, true);
+
+		} else if (type == Type.SPOT) {
+			SpotLightsAttribute la = (SpotLightsAttribute) scene.environment.get(SpotLightsAttribute.Type);
+			SpotLight sl = (SpotLight) lightData;
+
+			if (on && !la.lights.contains(sl, true))
+				la.lights.add(sl);
+			else if (!on && la.lights.contains(sl, true))
+				la.lights.removeValue(sl, true);
+
+		}
+
+	}
+
+	public boolean on(){
+		return on;
 	}
 
 }

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -517,19 +517,7 @@ public class Scene implements Named{
 			l.type = ll.type;
 			l.makeLightData();
 			l.updateLight();
-
-			if (l.lightData instanceof PointLight) {
-				PointLightsAttribute la = (PointLightsAttribute) environment.get(PointLightsAttribute.Type);
-				la.lights.add((PointLight) l.lightData);
-			}
-			else if (l.lightData instanceof DirectionalLight) {
-				DirectionalLightsAttribute la = (DirectionalLightsAttribute) environment.get(DirectionalLightsAttribute.Type);
-				la.lights.add((DirectionalLight) l.lightData);
-			}
-			else if (l.lightData instanceof SpotLight) {
-				SpotLightsAttribute la = (SpotLightsAttribute) environment.get(SpotLightsAttribute.Type);
-				la.lights.add((SpotLight) l.lightData);
-			}
+			l.on(true);
 
 		}
 


### PR DESCRIPTION
Allows the Lights to be turned on and off (added and removed from the environment's lights attribute list).
This won't assist with CPU / GPU usage for displaying these lights, but will influence if they are high-order and accurate, or factored in to LibGDX's vertex lighting. This addition means that you can set the maximum light size (say, 4), then get the 4 closest lights in-game and just turn those on.