### PR TITLE
(#858) Bug-fix - Altering render process to allow compositing before shaders.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -21,6 +21,7 @@ public class Bdx{
 
 	public static class Display{
 		public boolean changed;
+		public Color clearColor = new Color(0, 0, 0, 0);
 		
 		public int width(){
 			return Gdx.graphics.getWidth();
@@ -55,13 +56,6 @@ public class Bdx{
 		}
 		public boolean fullscreen(){
 			return Gdx.graphics.isFullscreen();
-		}
-		public void clearColor(Color color){
-			clearColor.set(color);
-			Gdx.gl.glClearColor(color.r, color.g, color.b, color.a);
-		}
-		public Color clearColor(){
-			return clearColor;
 		}
 		public static void advancedLighting(boolean on){
 			advancedLightingOn = on;
@@ -174,7 +168,6 @@ public class Bdx{
 	private static RenderBuffer frameBuffer;
 	private static RenderBuffer depthBuffer;
 	private static SpriteBatch spriteBatch;
-	private static Color clearColor;
 	private static BDXDepthShaderProvider depthShaderProvider;
 	private static HashMap<Float, RenderBuffer> availableTempBuffers;
 	private static boolean requestedRestart;
@@ -215,7 +208,6 @@ public class Bdx{
 		depthShaderProvider = new BDXDepthShaderProvider(Gdx.files.internal("bdx/shaders/3d/depthExtract.vert"), Gdx.files.internal("bdx/shaders/3d/depthExtract.frag"));
 
 		depthBatch = new ModelBatch(depthShaderProvider);
-		clearColor = new Color();
 
 		advancedLightingOn = true;
 
@@ -227,8 +219,20 @@ public class Bdx{
 
 	public static void main(){
 
+		boolean screenShadersUsed = false;
+
+		for (Scene scene : scenes) {
+			if (scene.screenShaders.size() > 0) {
+				screenShadersUsed = true;
+				break;
+			}
+		}
+
 		profiler.start("__render");
+		Gdx.gl.glClearColor(display.clearColor.r, display.clearColor.g, display.clearColor.b, display.clearColor.a);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		Gdx.gl.glClearColor(0, 0, 0, 0);
+		Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT);
 		profiler.stop("__render");
 
 		// -------- Update Input --------
@@ -251,7 +255,27 @@ public class Bdx{
 
 		Viewport vp;
 
-		for (Scene scene : (ArrayListScenes)scenes.clone()){
+		ArrayListScenes newSceneList = (ArrayListScenes) scenes.clone();
+
+		boolean depthBufferCleared = false;
+		boolean colorBufferCleared = false;
+
+		for (int i = 0; i < newSceneList.size(); i++){
+
+			Scene scene = newSceneList.get(i);
+			boolean prevSceneRenderPassthrough = false;
+			boolean nextSceneRenderPassthrough = false;
+
+			if (i > 0)
+				prevSceneRenderPassthrough = newSceneList.get(i - 1).renderPassthrough;
+
+			if (i < newSceneList.size() - 1)
+				nextSceneRenderPassthrough = newSceneList.get(i + 1).renderPassthrough;
+
+			if (!prevSceneRenderPassthrough) {
+				colorBufferCleared = false;
+				depthBufferCleared = false;
+			}
 
 			scene.update();
 			profiler.stop("__scene");
@@ -266,31 +290,38 @@ public class Bdx{
 
 			depthShaderProvider.update(scene);
 			shaderProvider.update(scene);
-			
-			if (scene.screenShaders.size() > 0){
+
+			boolean frameBufferInUse = false;
+
+			if (scene.screenShaders.size() > 0 || (screenShadersUsed && scene.renderPassthrough)) { // If the scene is passing its render output, and screen shaders are used, then it needs to use the framebuffer to pass the render on.
+																									// If screen shaders aren't used anywhere, there's no need to render to a framebuffer, as OpenGL will correctly blend normally.
 				frameBuffer.begin();
-				Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+				frameBufferInUse = true;
+				if (!colorBufferCleared) {            				// First rendering scene, or previous scene didn't pass a render, so it needs to clear the framebuffer.
+					Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);		// We only need to do this once - the rendered data can accumulate until the last scene renders or
+					colorBufferCleared = true;						// Another scene stops passing the render data up the stack
+				}
 			}
 
-			Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT);
+			Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT);				// We have to clear the depth buffer no matter what, because closer things on previous scenes should never
+																	// overlap further things on overlay scenes
 
 			renderWorld(modelBatch, scene, scene.camera);			// Render main view
 
-			for (Camera cam : scene.cameras){
+			for (Camera cam : scene.cameras){						// Render auxiliary cameras
 				if (cam.renderingToTexture){
 					cam.update();
 					if (cam.renderBuffer == null){
 						cam.initRenderBuffer();
 					}
 					cam.renderBuffer.begin();
-					Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT);
-					Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+					Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT | GL20.GL_COLOR_BUFFER_BIT);
 					renderWorld(modelBatch, scene, cam);
 					cam.renderBuffer.end();
 				}
 			}
 
-			if (scene.screenShaders.size() > 0){
+			if (frameBufferInUse) {
 
 				frameBuffer.end();
 
@@ -301,10 +332,14 @@ public class Bdx{
 						usingDepth = true;
 				}
 
-				if (usingDepth) {
+				if (usingDepth || scene.renderPassthrough) {									// Render depth texture
 					Gdx.gl.glClearColor(1, 1, 1, 1);
 					depthBuffer.begin();
-					Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT | GL20.GL_COLOR_BUFFER_BIT);
+					if (!depthBufferCleared) {
+						Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+						depthBufferCleared = true;
+					}
+					Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT );
 					renderWorld(depthBatch, scene, scene.camera);
 					depthBuffer.end();
 					depthBuffer.getColorBufferTexture().bind(2);
@@ -346,14 +381,13 @@ public class Bdx{
 
 				}
 
-				frameBuffer.drawTo(null, null, vp.x, vp.y, vp.w, vp.h); //  Draw to screen
+				if (!scene.renderPassthrough || scene == newSceneList.get(newSceneList.size() - 1) || !nextSceneRenderPassthrough)
+					frameBuffer.drawTo(null, null, vp.x, vp.y, vp.w, vp.h); //  Draw to screen, but only if the scene's not passing the render, or if it's the last scene in the list
 				scene.lastFrameBuffer.clear();
 				frameBuffer.drawTo(scene.lastFrameBuffer);
 			}
 
 			scene.executeDrawCommands();
-
-			display.clearColor(display.clearColor());
 
 			// ------- Render physics debug view --------
 

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -75,6 +75,7 @@ public class Scene implements Named{
 	public Viewport viewport;
 	public HashMap<String, GameObject> templates;
 	public ArrayList<ScreenShader> screenShaders;
+	public boolean renderPassthrough = true;
 	public RenderBuffer lastFrameBuffer;
 	public Environment environment;
 	static private ShapeRenderer shapeRenderer;
@@ -194,7 +195,7 @@ public class Scene implements Named{
 
 		if (!clearColorDefaultSet) {
 			float[] cc = json.get("clearColor").asFloatArray();
-			Bdx.display.clearColor(new Color(cc[0], cc[1], cc[2], 0));
+			Bdx.display.clearColor.set(cc[0], cc[1], cc[2], 0);
 			clearColorDefaultSet = true;
 		}
 

--- a/src/com/nilunder/bdx/gl/BDXDepthShaderProvider.java
+++ b/src/com/nilunder/bdx/gl/BDXDepthShaderProvider.java
@@ -20,11 +20,11 @@ class BDXDepthShader extends DepthShader {
 	}
 
 	public void render(Renderable renderable, Attributes combinedAttributes) {
-		super.render(renderable, combinedAttributes);
-		if (scene != null) {
+		if (scene != null) {													// The uniforms need to be set before rendering, haha, whoops
 			program.setUniformf("far", scene.camera.far());
 			program.setUniformf("near", scene.camera.near());
 		}
+		super.render(renderable, combinedAttributes);
 	}
 }
 


### PR DESCRIPTION
Scene.renderPassthrough added to accomodate this - the idea is that when this boolean is on, a scene's rendered output remains in the framebuffer for the next scene to render onto (unless that next scene doesn't pass it on or the passing scene is the last in the list; in that case, the scene will be rendered to the screen, as usual).

This process allows blended pixels to be rendered normally when screen shaders are used, and also allows one shader to run across multiple scenes. Turning off Scene.renderPassthrough should revert the screen shader application process to the "old" way of doing things. 

Controlling which scene's renders are passed through allows for more control (i.e. applying a shader on just, say, the GUI scene, but also applying a shader on multiple lower scenes at the same time).

The lightening when a shader is applied (also mentioned in #858) is due to calling glClear() more than once per frame. Changing this to clear the desired clear color once, and then clear black afterward also eliminated the need for clearColor to be a function - so it has been changed to a variable.

Bug in BDXDepthShaderProvider also fixed - uniforms need to be set before the rendering is done, not after.