### PR TITLE
#853 - Threading of run process.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -159,6 +159,7 @@ public class Bdx{
 	public static BDXShaderProvider shaderProvider;
 	public static float physicsSpeed;
 	public static float timeSpeed;
+	public static boolean restartOnExport = false;
 
 	private static boolean advancedLightingOn;
 	private static ArrayList<Finger> allocatedFingers;
@@ -216,6 +217,16 @@ public class Bdx{
 	}
 
 	public static void main(){
+
+		// --------- Auto reloading -------- //
+
+		if (restartOnExport) {
+			FileHandle done = Gdx.files.internal("finishedExport");
+			if (done.exists()) {
+				done.file().delete();
+				restart();
+			}
+		}
 
 		boolean screenShadersUsed = false;
 


### PR DESCRIPTION
The run process is now threaded. That means that we can no longer report from an operator (even if the operator's passed in manually, because of the lack of bpy data). Still, errors are printed to the console.

Export process finishes with a signal, by outputting a file to HDD. Simply checking the time modified of a .bdx file isn't sufficient, as the file may not be finished writing before that time is updated.

Adding Bdx.restartOnExport to automatically restart (and so, reload) BDX data if a new export is signaled.