### PR TITLE
#853 - Fix to save and re-open blend file after export.

### DIFF
--- a/blender/bdx/ops/exprun.py
+++ b/blender/bdx/ops/exprun.py
@@ -196,6 +196,12 @@ def export(self, context, multiBlend, diffExport):
     if not multiBlend:
         export_time = None
 
+    prev_auto_export = bpy.context.scene.bdx.auto_export
+    bpy.context.scene.bdx.auto_export = False
+    bpy.ops.wm.save_mainfile()                              # Save and reload to clear out orphan data left behind by
+    bpy.ops.wm.open_mainfile(filepath=bpy.data.filepath)    # linked scenes
+    bpy.context.scene.bdx.auto_export = prev_auto_export
+
 def run(self, context):
 
     global runThread


### PR DESCRIPTION
This clears orphan data left over from linked scenes.