### PR TITLE
Logic frequency improvements.

### DIFF
--- a/src/com/nilunder/bdx/Component.java
+++ b/src/com/nilunder/bdx/Component.java
@@ -1,20 +1,21 @@
 package com.nilunder.bdx;
 
 import com.nilunder.bdx.utils.Named;
+import com.nilunder.bdx.utils.Random;
 
 public class Component<T extends GameObject> implements Named {
 
 	public State state;
 	public String name;
 	protected T g;
-	public int logicFrequency;
+	public float logicFrequency;
 	public float logicCounter;
 
 	public Component(T g){
 		this.g = g;
 		name = this.getClass().getSimpleName();
 		logicFrequency = Bdx.TICK_RATE;
-		logicCounter = 1.0f;
+		logicCounter = 1 + Random.random();
 	}
 
 	@Override

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -64,7 +64,7 @@ public class GameObject implements Named{
 	private boolean visible;
 	private boolean valid;
 	public boolean initialized;
-	public int logicFrequency;
+	public float logicFrequency;
 	public float logicCounter;
 	private Vector3f scale;
 	private Mesh mesh;
@@ -119,7 +119,7 @@ public class GameObject implements Named{
 		valid = true;
 		scale = new Vector3f();
 		logicFrequency = Bdx.TICK_RATE;
-		logicCounter = 1;
+		logicCounter = 1 + Random.random();
 	}
 
 	public String name(){


### PR DESCRIPTION
- logicFrequency changed to float to allow for execution to happen less often than a full second.

- logicCounter now gets a random float added to it on GameObject / Component creation. This allows multiple objects that have altered frequency value to not be executed all on the same game frame (i.e. 1000 objects that have a logicFrequency of 1 will now execute evenly throughout a second, rather than all on the first frame).