### PR TITLE
Bug-fix - Create inst dir if it doesn't exist already.

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -861,6 +861,9 @@ def export(context, filepath, scene_name, exprun, apply_modifier):
 
             inst = j(ut.src_root(), "inst")
 
+            if not os.path.exists(inst):
+                os.mkdir(inst)
+
             with open(j(inst, class_name + ".java"), 'w') as f:
                 f.writelines(lines)
 


### PR DESCRIPTION
Not sure when or why this bug appears, but it doesn't seem like BDX projects are made with inst directories in the src directory anymore, making the export process fail (because the directory doesn't exist). This fixes that possible issue.