### PR TITLE
Profiler improvements.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -470,6 +470,9 @@ public class Bdx{
 	}
 
 	public static void end(){
+		if (profiler.visible())
+			profiler.gl.disable();
+
 		Gdx.app.exit();
 	}
 

--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -412,6 +412,10 @@ public class Profiler{
 		this.visible = visible;
 	}
 
+	public boolean tickInfoVisible(){
+		return tickInfoVisible;
+	}
+
 	public void tickInfoVisible(boolean visible){
 		if (!this.visible){
 			return;
@@ -421,6 +425,10 @@ public class Profiler{
 		}
 		tickInfoVisible = visible;
 		reinitialize();
+	}
+
+	public boolean subsystemsVisible(){
+		return subsystemsVisible;
 	}
 	
 	public void subsystemsVisible(boolean visible){
@@ -433,6 +441,10 @@ public class Profiler{
 		subsystemsVisible = visible;
 		reinitialize();
 	}
+
+	public boolean glVisible(){
+		return glVisible;
+	}
 	
 	public void glVisible(boolean visible){
 		if (!this.visible){
@@ -443,6 +455,10 @@ public class Profiler{
 		}
 		glVisible = visible;
 		reinitialize();
+	}
+
+	public boolean propsVisible(){
+		return propsVisible;
 	}
 	
 	public void propsVisible(boolean visible){


### PR DESCRIPTION
Adding getters for Profiler visibility() setters.
Bdx.end() now disables GL logging prior to ending, as it was causing a crash on application end if GL logging was left on.