### PR TITLE
Adding GPU Wait section to the profiler.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -214,11 +214,18 @@ public class Bdx{
 
 		availableTempBuffers = new HashMap<Float, RenderBuffer>();
 		requestedRestart = false;
+
+		profiler.start("__gpu wait");
+
 	}
 
 	public static void main(){
 
 		// --------- Auto reloading -------- //
+
+		profiler.stop("__gpu wait");
+
+		profiler.deltaTimes.put("__gpu wait", (long) Math.max(profiler.deltaTimes.get("__gpu wait") - (TICK_TIME * 1000000000), 0));
 
 		if (restartOnExport) {
 			FileHandle done = Gdx.files.internal("finishedExport");
@@ -440,6 +447,8 @@ public class Bdx{
 			init();
 			scenes.add(firstScene);
 		}
+
+		profiler.start("__gpu wait");
 
 	}
 

--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -242,7 +242,7 @@ public class Profiler{
 	private long totalStartTime;
 	private long totalDeltaTime;
 	private long lastStopTime;
-	private HashMap<String, Long> deltaTimes;
+	public HashMap<String, Long> deltaTimes;
 	private HashMap<String, Long> startTimes;
 	private ArrayList<Long> tickTimes;
 	private float counter;
@@ -327,6 +327,7 @@ public class Profiler{
 			"__scene",
 			"__physics",
 			"__outside",
+			"__gpu wait"
 		};
 		texts = new HashMap<String, Text>();
 		bars = new HashMap<String, GameObject>();
@@ -652,7 +653,7 @@ public class Profiler{
 		
 		addString(buffer, name, 14, false, ' ');
 		buffer.append(" ");
-		addFloat(buffer, avgTickTime, 4, 1, ' ');
+		addFloat(buffer, avgTickTime, 5, 1, ' ');
 		buffer.append(" ");
 		addString(buffer, timeUnits, 3, false, ' ');
 		buffer.append(" ");


### PR DESCRIPTION
While the "Render" category measures render functions calls, the GPU Wait category is for the amount of time the CPU waits on the GPU to actually perform those calls. An example of something that would demonstrate this phenomenon is running an especially heavy screen shader - the heavy part isn't in the engine's execution (and so won't normally be caught by the profiler), but rather something the GPU is taking a very long time to do. Any amount of time listed in this category indicates that the game is GPU bound. If this is the case, the game still has CPU time to spend, and the Profiler will still list it in Outside (as though the game were not GPU bound).

This most likely isn't super accurate, but it's still enough to be extremely helpful.