### PR TITLE
Changes to minimize number of shader switches when rendering.

### DIFF
--- a/src/com/nilunder/bdx/gl/BDXShaderProvider.java
+++ b/src/com/nilunder/bdx/gl/BDXShaderProvider.java
@@ -78,6 +78,11 @@ class BDXDefaultShader extends DefaultShader {
 
 		}
 
+		if (applyingMaterial != null && applyingMaterial.shader != null) {
+			for (UniformSet uniformSet : applyingMaterial.shader.uniformSets)
+				uniformSet.set(program);
+		}
+
 		super.render(renderable, combinedAttributes);
 	}
 

--- a/src/com/nilunder/bdx/gl/MaterialShader.java
+++ b/src/com/nilunder/bdx/gl/MaterialShader.java
@@ -5,18 +5,22 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.utils.Disposable;
 
+import java.util.ArrayList;
+
 public class MaterialShader implements Disposable{
 
 	public String vertexShader;
 	public String fragmentShader;
 	private String prefix;
 	public boolean active = true;
+	public ArrayList<UniformSet> uniformSets;
 
 	public com.badlogic.gdx.graphics.glutils.ShaderProgram programData;
 
 	public MaterialShader(String vertexShader, String fragmentShader) {
 		this.vertexShader = vertexShader;
 		this.fragmentShader = fragmentShader;
+		uniformSets = new ArrayList<UniformSet>();
 	}
 
 	public MaterialShader(FileHandle vertexShader, FileHandle fragmentShader) {

--- a/src/com/nilunder/bdx/gl/RenderBuffer.java
+++ b/src/com/nilunder/bdx/gl/RenderBuffer.java
@@ -38,10 +38,14 @@ public class RenderBuffer extends FrameBuffer{
 		if (dest != null)
 			dest.begin();
 
+		batch.setShader(filter);		// Set shader BEFORE calling begin() (avoids shader switching)
 		batch.begin();
+		if (filter != null) {
+			for (UniformSet uniformSet : filter.uniformSets)
+				uniformSet.set(filter);
+		}
 		batch.enableBlending();
 		batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
-		batch.setShader(filter);
 		batch.draw(region, x, y, w, h);
 		batch.end();
 		

--- a/src/com/nilunder/bdx/gl/ScreenShader.java
+++ b/src/com/nilunder/bdx/gl/ScreenShader.java
@@ -5,6 +5,8 @@ import javax.vecmath.Vector2f;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 
+import java.util.ArrayList;
+
 public class ScreenShader extends com.badlogic.gdx.graphics.glutils.ShaderProgram {
 
 	public Vector2f renderScale;
@@ -15,6 +17,7 @@ public class ScreenShader extends com.badlogic.gdx.graphics.glutils.ShaderProgra
 	public boolean active = true;
 	public String vertexShaderPath;
 	public String fragmentShaderPath;
+	public ArrayList<UniformSet> uniformSets;
 	
 	public ScreenShader(String vertexShader, String fragmentShader) {
 		super(vertexShader, fragmentShader);
@@ -39,6 +42,7 @@ public class ScreenShader extends com.badlogic.gdx.graphics.glutils.ShaderProgra
 
 		renderScale = new Vector2f(1, 1);
 		overlay = false;
+		uniformSets = new ArrayList<UniformSet>();
 	}
 	
 	public static ScreenShader load(String vertexPath, String fragmentPath) {

--- a/src/com/nilunder/bdx/gl/UniformSet.java
+++ b/src/com/nilunder/bdx/gl/UniformSet.java
@@ -1,0 +1,9 @@
+package com.nilunder.bdx.gl;
+
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+
+public abstract class UniformSet {
+
+    public abstract void set(ShaderProgram program);
+
+}


### PR DESCRIPTION
- Adding UniformSet to facilitate this. Its role is to allow an entry point to set uniforms from game code after the shader has been switched to in BDX's render loop (so now you don't have to call .begin() and .end() on a ScreenShader or MaterialShader's shaderProgram to set the uniforms).

- When drawing a RenderBuffer to a destination, the shader is set before calling batch.begin(), as that ends the previous shader, if there was one.

-  Don't render to the depth texture if unnecessary.