### PR TITLE
(#929) Search for actual name of font instead of data block name

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -243,7 +243,7 @@ def srl_models_text(texts, fntx_dir):
     j = os.path.join
 
     def fntx(t):
-        with open(j(fntx_dir, t.font.name + ".fntx"), 'r') as f:
+        with open(j(fntx_dir, t.font.filepath.split("\\")[-1].split(".")[0] + ".fntx"), 'r') as f:
             data = json.load(f)
         return data
 


### PR DESCRIPTION
since the fontwriter uses the actual name of the font