### PR TITLE
(#878) - Removing available() functions from Sounds, Music, and Bdx.scenes.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -141,13 +141,6 @@ public class Bdx{
 			int index = indexOf(get(name));
 			return remove(index);
 		}
-		public ArrayList<String> available(){
-			ArrayList<String> scenes = new ArrayList<String>();
-			FileHandle[] files = Gdx.files.internal("bdx/scenes/").list("bdx");
-			for (FileHandle file : files)
-				scenes.add(file.nameWithoutExtension());
-			return scenes;
-		}
 	}
 
 	public static final int TICK_RATE = 60;

--- a/src/com/nilunder/bdx/audio/Music.java
+++ b/src/com/nilunder/bdx/audio/Music.java
@@ -26,16 +26,6 @@ public class Music extends AudioStore<BDXMusic> implements Disposable {
 			m.dispose();
 	}
 
-	public ArrayList<String> available(){
-		ArrayList<String> tracks = new ArrayList<String>();
-
-		FileHandle[] files = Gdx.files.internal("bdx/audio/music/").list("");
-		for (FileHandle file : files)
-			tracks.add(file.nameWithoutExtension());
-
-		return tracks;
-	}
-
 	public void volume(float volume){
 		this.volume = volume;
 		for (BDXMusic music : values())

--- a/src/com/nilunder/bdx/audio/Sounds.java
+++ b/src/com/nilunder/bdx/audio/Sounds.java
@@ -27,16 +27,6 @@ public class Sounds extends AudioStore<BDXSound> implements Disposable{
 			s.dispose();
 	}
 
-	public ArrayList<String> available(){
-		ArrayList<String> tracks = new ArrayList<String>();
-
-		FileHandle[] files = Gdx.files.internal("bdx/audio/sounds/").list("");
-		for (FileHandle file : files)
-			tracks.add(file.nameWithoutExtension());
-
-		return tracks;
-	}
-
 	public void volume(float volume) {
 		this.volume = volume;
 	}


### PR DESCRIPTION
Rather than us recording which files are available in which folders, one can just write a script to output a file listing available resources and run it before export and/or before testing.