### PR TITLE
Bug-fix: Only end Profiler.scene if it exists.

### DIFF
--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -543,10 +543,10 @@ public class Profiler{
 	}
 	
 	public void end(){
-		if (gl.active()){
+		if (gl.active())
 			gl.active(false);
-		}
-		scene.end();
+		if (scene != null)
+			scene.end();
 	}
 	
 	public String tickInfoAsString(){


### PR DESCRIPTION
Profiler.scene is null if the profiler isn't turned on in Blender first.