### PR TITLE
Global downsampling bug-fixes.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -509,6 +509,10 @@ public class Bdx{
 	}
 
 	public static void dispose(){
+
+		for (Scene s : scenes)
+			s.dispose();
+
 		modelBatch.dispose();
 		depthBatch.dispose();
 		spriteBatch.dispose();
@@ -519,9 +523,6 @@ public class Bdx{
 
 		for (RenderBuffer b : availableTempBuffers.values())
 			b.dispose();
-		for (Scene s : scenes) {
-			s.dispose();
-		}
 
 	}
 

--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -342,8 +342,8 @@ public class Bdx{
 						program.setUniformf("time", Bdx.time);
 						program.setUniformi("lastFrame", 1);
 						program.setUniformi("depthTexture", 2);
-						program.setUniformf("screenWidth", vpw);
-						program.setUniformf("screenHeight", vph);
+						program.setUniformf("screenWidth", vpw * display.downsample());
+						program.setUniformf("screenHeight", vph * display.downsample());
 						program.setUniformf("near", scene.camera.near());
 						program.setUniformf("far", scene.camera.far());
 					}
@@ -357,9 +357,8 @@ public class Bdx{
 			for (Camera cam : scene.cameras){						// Render auxiliary cameras
 				if (cam.renderToTexture){
 					cam.update();
-					if (cam.renderBuffer == null){
-						cam.initRenderBuffer();
-					}
+					if (cam.renderBuffer == null)
+						cam.updateRenderBuffer();
 					cam.renderBuffer.begin();
 					Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT | GL20.GL_COLOR_BUFFER_BIT);
 					renderWorld(modelBatch, scene, cam);
@@ -416,13 +415,13 @@ public class Bdx{
 					if (!filter.uniformSets.contains(defaultScreenShaderUniformSet))
 						filter.uniformSets.add(defaultScreenShaderUniformSet);
 
-					if (!availableTempBuffers.containsKey(filter.renderScale.x * display.downsample())) {
-						int fx = Math.max(1, (int) (Gdx.graphics.getWidth() * display.downsample()));
-						int fy = Math.max(1, (int) (Gdx.graphics.getHeight() * display.downsample()));
-						availableTempBuffers.put(filter.renderScale.x * display.downsample(), new RenderBuffer(spriteBatch, fx, fy));
+					if (!availableTempBuffers.containsKey(filter.renderScale.x)) {
+						int fx = Math.max(1, (int) (vp.size().x * filter.renderScale.x * display.downsample()));
+						int fy = Math.max(1, (int) (vp.size().y * filter.renderScale.y * display.downsample()));
+						availableTempBuffers.put(filter.renderScale.x, new RenderBuffer(spriteBatch, fx, fy));
 					}
 
-					RenderBuffer tempBuffer = availableTempBuffers.get(filter.renderScale.x * display.downsample);
+					RenderBuffer tempBuffer = availableTempBuffers.get(filter.renderScale.x);
 
 					tempBuffer.clear();
 
@@ -552,11 +551,8 @@ public class Bdx{
 
 		for (Scene scene : scenes) {
 
-			for (Camera cam : scene.cameras) {                // Have to do this, as the RenderBuffers need to be resized for the new window size
-				if (cam.renderBuffer != null)
-					cam.renderBuffer.dispose();
-				cam.renderBuffer = null;
-			}
+			for (Camera cam : scene.cameras)
+				cam.updateRenderBuffer();
 
 			if (scene.lastFrameBuffer != null)
 				scene.lastFrameBuffer.dispose();

--- a/src/com/nilunder/bdx/Camera.java
+++ b/src/com/nilunder/bdx/Camera.java
@@ -169,15 +169,17 @@ public class Camera extends GameObject{
 		data.up.set(axis.x, axis.y, axis.z);
 		data.update();
 	}
-	
-	public void initRenderBuffer(){
-		renderBuffer = new RenderBuffer(null, Math.round(resolution.x), Math.round(resolution.y));
-	}
-	
+
 	public void updateRenderBuffer(){
-		if (renderBuffer != null)
-			renderBuffer.dispose();
-		initRenderBuffer();
+
+		int targetX = Math.max(1, Math.round(resolution.x * Bdx.display.downsample()));
+		int targetY = Math.max(1, Math.round(resolution.y * Bdx.display.downsample()));
+
+		if (renderBuffer == null || (renderBuffer.getWidth() != targetX || renderBuffer.getHeight() != targetY)) {
+			if (renderBuffer != null)
+				renderBuffer.dispose();
+			renderBuffer = new RenderBuffer(null, targetX, targetY);
+		}
 	}
 	
 	public TextureRegion texture(){

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -624,6 +624,11 @@ public class GameObject implements Named{
 
 		if (modelInstance != null)
 			mesh.instances.remove(modelInstance);
+
+		if (mesh.instances.size() == 0 && mesh.autoDispose)
+			mesh.dispose();
+
+		mesh = null;
 	}
 
 	public boolean valid(){
@@ -861,13 +866,15 @@ public class GameObject implements Named{
 	}
 	
 	public void join(ArrayList<GameObject> objects, boolean endObjects){
-		
+
 		// collect scaled transforms per mesh
 		
 		HashMap<Mesh, ArrayList<Matrix4f>> map = new HashMap<Mesh, ArrayList<Matrix4f>>();
 		Mesh m;
 		for (GameObject g : objects){
 			m = g.mesh();
+			if (!g.valid() || !m.valid())
+				continue;
 			ArrayList<Matrix4f> l;
 			if (map.containsKey(m)){
 				l = map.get(m);
@@ -879,9 +886,8 @@ public class GameObject implements Named{
 			Vector3f s = g.scale();
 			t.setRow(3, s.x, s.y, s.z, 0);
 			l.add(t);
-			if (endObjects){
-				g.end();
-			}
+			if (endObjects)
+				g.endNoChildren();
 		}
 		
 		// join

--- a/src/com/nilunder/bdx/audio/Audio.java
+++ b/src/com/nilunder/bdx/audio/Audio.java
@@ -17,6 +17,8 @@ public class Audio {
     public void dispose(){
         music.dispose();
         sounds.dispose();
+        music = null;
+        sounds = null;
     }
 
     public void volume(float volume){

--- a/src/com/nilunder/bdx/audio/BDXMusic.java
+++ b/src/com/nilunder/bdx/audio/BDXMusic.java
@@ -97,6 +97,7 @@ public class BDXMusic {
 
     public void dispose() {
         data.dispose();
+        data = null;
     }
 
 }

--- a/src/com/nilunder/bdx/audio/BDXSound.java
+++ b/src/com/nilunder/bdx/audio/BDXSound.java
@@ -68,6 +68,7 @@ public class BDXSound {
 
     public void dispose() {
         data.dispose();
+        data = null;
     }
 
     public void pause(long handleID) {

--- a/src/com/nilunder/bdx/audio/Music.java
+++ b/src/com/nilunder/bdx/audio/Music.java
@@ -24,6 +24,7 @@ public class Music extends AudioStore<BDXMusic> implements Disposable {
 	public void dispose(){
 		for (BDXMusic m : values())
 			m.dispose();
+		clear();
 	}
 
 	public void volume(float volume){

--- a/src/com/nilunder/bdx/audio/Sounds.java
+++ b/src/com/nilunder/bdx/audio/Sounds.java
@@ -25,6 +25,7 @@ public class Sounds extends AudioStore<BDXSound> implements Disposable{
 	public void dispose(){
 		for (BDXSound s : values())
 			s.dispose();
+		clear();
 	}
 
 	public void volume(float volume) {

--- a/src/com/nilunder/bdx/gl/Material.java
+++ b/src/com/nilunder/bdx/gl/Material.java
@@ -6,11 +6,12 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.g3d.Attribute;
 import com.badlogic.gdx.graphics.g3d.attributes.*;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Disposable;
 import com.nilunder.bdx.Scene;
 import com.nilunder.bdx.utils.Color;
 import com.nilunder.bdx.utils.Named;
 
-public class Material extends com.badlogic.gdx.graphics.g3d.Material implements Named {
+public class Material extends com.badlogic.gdx.graphics.g3d.Material implements Named, Disposable {
 
 	public Texture currentTexture;
 	public Shader shader;
@@ -162,6 +163,15 @@ public class Material extends com.badlogic.gdx.graphics.g3d.Material implements 
 			this.set(TextureAttribute.createDiffuse(texRegion));
 			texturePath = null;
 		}
+	}
+
+	public void dispose() {
+		if (shader != null)
+			shader.dispose();
+		shader = null;
+		if (currentTexture != null)
+			currentTexture.dispose();
+		currentTexture = null;
 	}
 
 }

--- a/src/com/nilunder/bdx/gl/Mesh.java
+++ b/src/com/nilunder/bdx/gl/Mesh.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.g3d.model.MeshPart;
 import com.badlogic.gdx.graphics.g3d.model.NodePart;
 import com.badlogic.gdx.math.Matrix3;
 import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.JsonReader;
 import com.nilunder.bdx.Bdx;
@@ -21,13 +22,14 @@ import javax.vecmath.Vector3f;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-public class Mesh implements Named {
+public class Mesh implements Named, Disposable {
 
 	public Model model;
 	public String name;
 	public Scene scene;
 	public ArrayListMaterials materials;
 	public ArrayList<ModelInstance> instances;
+	public boolean autoDispose;
 
 	public class ArrayListMaterials extends ArrayListNamed<Material> {
 
@@ -82,6 +84,7 @@ public class Mesh implements Named {
 		for (NodePart part : model.nodes.get(0).parts)
 			materials.add((Material) part.material);
 		instances = new ArrayList<ModelInstance>();
+		autoDispose = true;
 	}
 	
 	public int numIndices(){
@@ -102,10 +105,6 @@ public class Mesh implements Named {
 	
 	public Mesh(Model model, Scene scene){
 		this(model, scene, model.meshParts.first().id);
-	}
-
-	protected void finalize() throws Throwable {
-		model.dispose();
 	}
 
     public int getVertexCount(int materialSlot){
@@ -249,6 +248,8 @@ public class Mesh implements Named {
 			part.material = newMat;
 		}
 
+		scene.meshCopies.add(newMesh);
+
 		return newMesh;
 	}
 
@@ -269,5 +270,16 @@ public class Mesh implements Named {
 	}
 
 	// Also UV, Normal, and Transforms (and possibly "do this to all" versions that don't use transforms?)
+
+	public void dispose() {
+		scene.meshCopies.remove(this);
+		if (model != null)
+			model.dispose();
+		model = null;
+	}
+
+	public boolean valid() {
+		return model != null;
+	}
 
 }


### PR DESCRIPTION
Previous commit broke local ScreenShader renderScale downsampling - this commit fixes them.
Also fixes factoring in downsampling for Cameras' renderbuffer sizes.
Also factors in downsampling into default screen shader uniforms.
I also cleaned up Camera's renderbuffer code a tiny bit, removing an unnecessary function.
We used to dispose of and nullify camera render buffers when the window is resized, but that's unnecessary - we can just update the renderbuffer at that moment, saving a frame where the renderbuffer's nullified and the texture's invalid.