### PR TITLE
More memory fixes to be able to properly GC scenes after usage.

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -205,7 +205,7 @@ public class GameObject implements Named{
 			if (compound && compShapeOld != null)
 				scene.world.addRigidBody(body);
 
-		}else{
+		}else if (valid()) {
 			dynamics(true);
 		}
 	}
@@ -604,9 +604,8 @@ public class GameObject implements Named{
 
 	public void end(){
 		endNoChildren();
-		for (GameObject g : new ArrayList<GameObject>(children)){
+		for (GameObject g : new ArrayList<GameObject>(children))
 			g.end();
-		}
 	}
 	
 	public void endNoChildren(){
@@ -625,10 +624,6 @@ public class GameObject implements Named{
 		if (modelInstance != null)
 			mesh.instances.remove(modelInstance);
 
-		if (mesh.instances.size() == 0 && mesh.autoDispose)
-			mesh.dispose();
-
-		mesh = null;
 	}
 
 	public boolean valid(){

--- a/src/com/nilunder/bdx/Light.java
+++ b/src/com/nilunder/bdx/Light.java
@@ -94,6 +94,9 @@ public class Light extends GameObject {
 	@Override
 	public void endNoChildren(){
 
+		if (!valid())
+			return;
+
 		if (type.equals(Type.POINT))
 			((PointLightsAttribute) scene.environment.get(PointLightsAttribute.Type)).lights.removeValue((PointLight) lightData, true);		// Remove the light from the environment
 		if (type.equals(Type.SUN))

--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -164,6 +164,7 @@ public class Scene implements Named{
 		defaultMaterial.set(new BlendingAttribute());
 		defaultMaterial.set(new BDXColorAttribute(BDXColorAttribute.Tint, 0, 0, 0));
 		defaultMesh = new Mesh(new ModelBuilder().createBox(1.0f, 1.0f, 1.0f, defaultMaterial, Usage.Position | Usage.Normal | Usage.TextureCoordinates), this);
+		defaultMesh.autoDispose = false;
 
 		meshes = new HashMap<String, Mesh>();
 		meshCopies = new ArrayList<Mesh>();
@@ -409,7 +410,9 @@ public class Scene implements Named{
 		valid = false;
 
 		for (GameObject g : objects)
-			g.end();
+			g.endNoChildren();
+
+		removeObjects();
 
 		lastFrameBuffer.dispose();
 		lastFrameBuffer = null;
@@ -871,12 +874,24 @@ public class Scene implements Named{
 		}
 		toBeAdded.clear();
 
+		removeObjects();
+
+	}
+
+	private void removeObjects() {
+
 		for (GameObject g : toBeRemoved) {
 			g.parent(null);
 			world.removeRigidBody(g.body);
+			g.body.setUserPointer(null);
 			objects.remove(g);
 			if (g instanceof Light)
 				lights.remove(g);
+
+			if (g.mesh().instances.size() == 0 && g.mesh().autoDispose)
+				g.mesh().dispose();
+
+			scene = null;
 		}
 		toBeRemoved.clear();
 

--- a/src/com/nilunder/bdx/gl/BDXShaderProvider.java
+++ b/src/com/nilunder/bdx/gl/BDXShaderProvider.java
@@ -80,8 +80,10 @@ class BDXDefaultShader extends DefaultShader {
 		}
 
 		if (applyingMaterial != null && applyingMaterial.shader != null) {
-			for (UniformSet uniformSet : applyingMaterial.shader.uniformSets)
+			for (UniformSet uniformSet : applyingMaterial.shader.uniformSets) {
+				uniformSet.scene = shaderProvider.scene;
 				uniformSet.set(program);
+			}
 		}
 
 		super.render(renderable, combinedAttributes);

--- a/src/com/nilunder/bdx/gl/Mesh.java
+++ b/src/com/nilunder/bdx/gl/Mesh.java
@@ -276,6 +276,7 @@ public class Mesh implements Named, Disposable {
 		if (model != null)
 			model.dispose();
 		model = null;
+		scene = null;
 	}
 
 	public boolean valid() {

--- a/src/com/nilunder/bdx/gl/UniformSet.java
+++ b/src/com/nilunder/bdx/gl/UniformSet.java
@@ -1,8 +1,11 @@
 package com.nilunder.bdx.gl;
 
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.nilunder.bdx.Scene;
 
 public abstract class UniformSet {
+
+    public Scene scene;
 
     public abstract void set(ShaderProgram program);
 


### PR DESCRIPTION
Having the Scene reference in the screen shader uniform set section be final was messing with the JVM's ability to garbage collect it later - this has since been rectified by adding a scene field on the UniformSet that's set before running its set() function.
We also want to remove objects if dispose() is called on a scene (and so, I moved that logic into a private function).