### PR TITLE
Minor Mesh-related fixes.

### DIFF
--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -734,20 +734,8 @@ public class GameObject implements Named{
 
 	public void mesh(String meshName){
 
-		Mesh m = null;
+		Mesh m = scene.meshes.get(meshName);
 
-		ArrayList<Scene> sceneList = new ArrayList<Scene>(Bdx.scenes);
-		
-		if (sceneList.indexOf(scene) >= 0)
-			Collections.swap(sceneList, sceneList.indexOf(scene), 0);
-		else
-			sceneList.add(0, scene);
-
-		for (Scene sce : sceneList){
-			m = sce.meshes.get(meshName);
-			if (m != null)
-				break;
-		}
 		if (m == null)
 			throw new RuntimeException("No model found with name '" + meshName + "' in an active scene.");
 
@@ -789,7 +777,7 @@ public class GameObject implements Named{
 		Matrix4 trans;
 		if (modelInstance != null) {
 			trans = modelInstance.transform;
-			this.mesh.instances.remove(this);
+			this.mesh.instances.remove(modelInstance);
 		}
 		else
 			trans = new Matrix4();

--- a/src/com/nilunder/bdx/gl/Mesh.java
+++ b/src/com/nilunder/bdx/gl/Mesh.java
@@ -272,7 +272,8 @@ public class Mesh implements Named, Disposable {
 	// Also UV, Normal, and Transforms (and possibly "do this to all" versions that don't use transforms?)
 
 	public void dispose() {
-		scene.meshCopies.remove(this);
+		if (scene != null)
+			scene.meshCopies.remove(this);
 		if (model != null)
 			model.dispose();
 		model = null;


### PR DESCRIPTION
Mesh.dispose() shouldn't crash if it's called multiple times.
GameObject.mesh(String meshName) shouldn't search other scenes for their meshes, since those meshes will be destroyed when that scene is ended.
GameObject.mesh(Mesh m) should remove the model instance from the mesh's instances list, not the GameObject (not sure why this one even compiled).