### PR TITLE
Destroy physics world on scene end.

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -446,6 +446,9 @@ public class Scene implements Named{
 			m.dispose();
 		meshCopies.clear();
 
+		world.destroy();
+		world = null;
+
 	}
 	
 	private void hookParentChild(){
@@ -882,7 +885,8 @@ public class Scene implements Named{
 
 		for (GameObject g : toBeRemoved) {
 			g.parent(null);
-			world.removeRigidBody(g.body);
+			if (g.body.isInWorld())
+				world.removeRigidBody(g.body);
 			g.body.setUserPointer(null);
 			objects.remove(g);
 			if (g instanceof Light)
@@ -933,7 +937,7 @@ public class Scene implements Named{
 			try{
 				world.stepSimulation(Bdx.TICK_TIME * Bdx.physicsSpeed, 0);
 			}catch (NullPointerException e){
-				throw new RuntimeException("PHYSICS ERROR: Detected collision between Static objects set to Ghost, with Triangle Mesh bounds: Keep them seperated, or use different bounds.");
+				throw new RuntimeException("PHYSICS ERROR: Detected collision between Static objects set to Ghost, with Triangle Mesh bounds: Keep them separated, or use different bounds.");
 			}
 			Bdx.profiler.stop("__physics");
 


### PR DESCRIPTION
Also only remove bodies from the physics world if they reside in the world.
Also a minor typo fix.

Note that I'm not certain if calling world.destroy() is necessary for correct cleanup of the physics world, but I don't see any marked worse behavior when calling it. It's possible that it _is_ needed considering that Java lacks destructors, the [Bullet example explicitly deletes the physics world after use](http://www.bulletphysics.org/mediawiki-1.5.8/index.php/Hello_World), and that memory leaks could be possible, even if physics worlds are properly cleaned up by the GC (as we already know from LibGDX's memory management). 

The JavaDoc doesn't say anything specifically about the destroy functions, though - neither does the C++ API.