### PR TITLE
Bug-fix - set GameObjects' scene reference to null.

### DIFF
--- a/src/com/nilunder/bdx/Scene.java
+++ b/src/com/nilunder/bdx/Scene.java
@@ -895,7 +895,7 @@ public class Scene implements Named{
 			if (g.mesh().instances.size() == 0 && g.mesh().autoDispose)
 				g.mesh().dispose();
 
-			scene = null;
+			g.scene = null;
 		}
 		toBeRemoved.clear();
 


### PR DESCRIPTION
Basically, this was a typo - it introduced a bug that prevents scenes from restarting.