### PR TITLE
Rendering to framebuffer fixes.

### DIFF
--- a/src/com/nilunder/bdx/Bdx.java
+++ b/src/com/nilunder/bdx/Bdx.java
@@ -345,9 +345,6 @@ public class Bdx{
 
 			// ------- Render Scene --------
 
-			vp = scene.viewport;
-			vp.apply();
-
 			depthShaderProvider.update(scene);
 			shaderProvider.update(scene);
 
@@ -362,6 +359,9 @@ public class Bdx{
 					cam.renderBuffer.end();
 				}
 			}
+
+			vp = scene.viewport;
+			vp.apply();
 
 			boolean frameBufferInUse = false;
 
@@ -512,7 +512,7 @@ public class Bdx{
 	private static void renderWorld(ModelBatch batch, Scene scene, Camera camera){
 		batch.begin(camera.data);
 		for (GameObject g : scene.objects){
-			if (g.visible() && (!g.frustumCulling || g.insideFrustum()) && !camera.ignoreObjects.contains(g))
+			if (g.visible() && (!g.frustumCulling || g.insideFrustum(null, camera)) && !camera.ignoreObjects.contains(g))
 				batch.render(g.modelInstance, scene.environment);
 		}
 		batch.end();

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -1139,7 +1139,7 @@ public class GameObject implements Named{
 		body.forceActivationState(2);
 	}
 
-	public boolean insideFrustum(Vector3f customHalfDim){
+	public boolean insideFrustum(Vector3f customHalfDim, Camera camera) {
 		Vector3f min = new Vector3f();
 		Vector3f max = new Vector3f();
 		body.getAabb(min, max);
@@ -1154,11 +1154,11 @@ public class GameObject implements Named{
 		if (customHalfDim == null)
 			customHalfDim = dimHalved;
 
-		return scene.camera.data.frustum.boundsInFrustum(center.x, center.y, center.z, customHalfDim.x, customHalfDim.y, customHalfDim.z);
+		return camera.data.frustum.boundsInFrustum(center.x, center.y, center.z, customHalfDim.x, customHalfDim.y, customHalfDim.z);
 	}
 
 	public boolean insideFrustum(){
-		return insideFrustum(null);
+		return insideFrustum(null, scene.camera);
 	}
 
 	public Vector3f vecTo(Vector3f vector){


### PR DESCRIPTION
The scene's viewport is now applied after framebuffer rendering, fixing the scene's viewport not taking effect if rendering a camera's texture to frame buffer.

GameObject.insideFrustum() changed to take the rendering camera as an argument (so objects rendered by a camera to a framebuffer now can properly determine if they're in that camera's frustum, and not that of the main scene camera).