### PR TITLE
(#673) Cancel and notify user if project already exists

### DIFF
--- a/blender/bdx/ops/createproj.py
+++ b/blender/bdx/ops/createproj.py
@@ -265,6 +265,12 @@ class CreateBdxProject(bpy.types.Operator):
     def execute(self, context):
         context.window.cursor_set("WAIT")
 
+        sc_bdx = context.scene.bdx
+        proj_path = j(ut.project_root(), sc_bdx.dir_name, sc_bdx.proj_name)
+        if os.path.exists(proj_path):
+            raise Exception("BDX project " + proj_path + " already exists.")
+            return {'CANCELLED'}
+
         self.create_libgdx_project()
         self.create_android_assets_bdx()
         self.create_blender_assets()


### PR DESCRIPTION
@GoranM 
>I guess it would be a good idea to have some code that would detect that error condition, and notify the user.

This would just raise an exception and cancel before building. Would you rather want this exception to be raised when it's already building, let me know. But as far as I know in such case also `utils.project_name()` will throw errors...