### PR TITLE
Update Profiler gl stats on initialization

### DIFF
--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -29,6 +29,7 @@ public class Profiler{
 			stats = new LinkedHashMap<String, Integer>();
 			fields = new HashMap<String, Integer>();
 			updateFields();
+			updateStats();
 		}
 		
 		public boolean active(){


### PR DESCRIPTION
Bug fix: calling gl stats on the first logic tick will throw a NullPointerException.