### PR TITLE
(#874) - Delta timing / Unlocked FPS.

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -852,6 +852,7 @@ def export(context, filepath, scene_name, exprun, apply_modifier):
         "clearColor": clear_color,
         "resolution": [scene.render.resolution_x, scene.render.resolution_y],
         "frame_type": scene.game_settings.frame_type,
+        "maxSubsteps": scene.game_settings.physics_step_max
     }
 
     if exprun:

--- a/blender/bdx/gen/BdxApp.java
+++ b/blender/bdx/gen/BdxApp.java
@@ -8,8 +8,11 @@ import com.nilunder.bdx.*;
 
 public class BdxApp implements ApplicationListener {
 
+	public int TICK_RATE = 60;
+
 	@Override
 	public void create(){
+		Bdx.TICK_RATE = this.TICK_RATE;
 		Bdx.init();
 
 		Scene.instantiators = new HashMap<String, Instantiator>();

--- a/blender/bdx/gen/DesktopLauncher.java
+++ b/blender/bdx/gen/DesktopLauncher.java
@@ -11,9 +11,15 @@ public class DesktopLauncher {
 		config.title = "Project Name";
 		config.width = 666;
 		config.height = 444;
+		config.foregroundFPS = 60;
+		config.backgroundFPS = 60;
+		config.vSyncEnabled = false;
+
+		BdxApp app = new BdxApp();
+		app.TICK_RATE = config.foregroundFPS;
 		config.addIcon("bdx/icon_128.png", Files.FileType.Internal);
 		config.addIcon("bdx/icon_32.png", Files.FileType.Internal);
 		config.addIcon("bdx/icon_16.png", Files.FileType.Internal);
-		new LwjglApplication(new BdxApp(), config);
+		new LwjglApplication(app, config);
 	}
 }

--- a/blender/bdx/ops/exprun.py
+++ b/blender/bdx/ops/exprun.py
@@ -193,6 +193,11 @@ def export(self, context, multiBlend, diffExport):
     ut.set_file_var(dl, "width", rx)
     ut.set_file_var(dl, "height", ry)
 
+    fps = str(current_scene.game_settings.fps)
+
+    ut.set_file_var(dl, "foregroundFPS", fps)
+    ut.set_file_var(dl, "backgroundFPS", fps)
+
     # - AndroidLauncher.java
     al = j(ut.src_root("android", "AndroidLauncher.java"), "AndroidLauncher.java")
     ut.set_file_var(al, "width", rx)

--- a/src/com/nilunder/bdx/GameObject.java
+++ b/src/com/nilunder/bdx/GameObject.java
@@ -399,15 +399,17 @@ public class GameObject implements Named{
 		
 		orientation(ori);
 	}
-	
-	public void applyForce(Vector3f vec){
+
+	public void applyForce(Vector3f force){
 		activate();
-		body.applyCentralForce(vec.mul(1f / Bdx.physicsSpeed));
+		// The multiplication factor takes into account physics speed, tick time, and delta because it's a one-time
+		// force push. Without this, the force generated changes based on framerate and substep amount.
+		body.applyCentralForce(force.mul(1f / Bdx.physicsSpeed * Bdx.TICK_TIME / Bdx.delta()));
 	}
 
 	public void applyForce(Vector3f force, Vector3f relPos) {
 		activate();
-		body.applyForce(force.mul(1f / Bdx.physicsSpeed), relPos);
+		body.applyForce(force.mul(1f / Bdx.physicsSpeed * Bdx.TICK_TIME / Bdx.delta()), relPos);
 	}
 
 	public void applyForce(float x, float y, float z){
@@ -428,9 +430,9 @@ public class GameObject implements Named{
 		applyForce(orientation().mult(force), relPos);
 	}
 
-	public void applyTorque(Vector3f vec){
+	public void applyTorque(Vector3f torque){
 		activate();
-		body.applyTorque(vec.mul(1f / Bdx.physicsSpeed));
+		body.applyTorque(torque.mul(1f / Bdx.physicsSpeed * Bdx.TICK_TIME / Bdx.delta()));
 	}
 	
 	public void applyTorque(float x, float y, float z){

--- a/src/com/nilunder/bdx/utils/Profiler.java
+++ b/src/com/nilunder/bdx/utils/Profiler.java
@@ -149,7 +149,7 @@ public class Profiler{
 		startTimes = new HashMap<String, Long>();
 		tickTimes = new ArrayList<Long>();
 		for (int i = 0; i < Bdx.TICK_RATE; i++){
-			tickTimes.add((long) Bdx.TICK_TIME);
+			tickTimes.add((long) Bdx.delta());
 		}
 		counter = 1;
 		scale = 1;
@@ -181,7 +181,7 @@ public class Profiler{
 		
 		frequency = Bdx.TICK_RATE;
 		avgTickRate = Bdx.TICK_RATE;
-		avgTickTime = Bdx.TICK_TIME;
+		avgTickTime = Bdx.delta();
 		
 		gl = new Gl();
 		props = new HashMap<String, Object>();
@@ -402,7 +402,7 @@ public class Profiler{
 			updateTextProps();
 			updateBackground();
 		}
-		counter += frequency * Bdx.TICK_TIME;
+		counter += frequency * Bdx.delta();
 		scene.viewport.apply();
 	}
 	
@@ -667,7 +667,7 @@ public class Profiler{
 		buffer.append(SPACE);
 		addString(buffer, timeUnits, 3, false, ' ');
 		buffer.append(SPACE);
-		addFloat(buffer, avgTickRate, 4, 1, ' ');
+		addFloat(buffer, avgTickRate, 5, 1, ' ');
 		buffer.append(SPACE);
 		buffer.append(valueUnits);
 		return buffer.toString();


### PR DESCRIPTION
The desired target framerate is now exported from the currently active blend file, though the framerate is only explicitly set for the Desktop target. On other platforms, it should remain at 60 FPS. Substeps have also been implemented. As follows is the proposed write-up on substeps and the API additions.

## What's a substep?

The graphical framerate is now unlocked from the logical and physics tickrate through the addition of _substeps_. If the framerate drops such that the game cannot maintain its graphical framerate, the physics world will be stepped through again, and logic re-calculated, as well. This keeps the game world up to speed with the graphical representation. So, if the game normally runs at 60 FPS, but is slow at rendering and now is rendering at 20 FPS, then BDX can try using substeps to keep the game _running_ at full speed, even if the game's _rendering_  slowly. (60 FPS target / 20 FPS minimum = 3 substeps needed to keep game running at full speed)

Put more simply, __a substep is basically just an event where BDX calculates physics and logic__. Before, BDX was built to use only one substep for each rendered frame. Now, it can use more, and will automatically use the appropriate number between the minimum and maximum substep counts. Physics and logic are both executed in a substep, and with more substep execution comes a finer physics simulation. If you're making a precise physics-focused game, you could consider using higher minimum substep counts for a more precise physics simulation.

## How often will BDX use substeps?

How often BDX will use substeps is automatically determined, with the goal being to keep the physics world and logic execution up to speed with the target FPS as best as possible. It will be a value between the specified minimum and maximum substep counts. The maximum number of substeps is exported from the currently active blend file and read when BDX first starts. The minimum is, by default, 1.

_______

API additions:

- Bdx.display.averageFPS() - Returns average FPS (Gdx.graphics.getFramesPerSecond()).
- Bdx.rawDelta() - Returns the delta between the last rendered frame and this one.
- Bdx.delta() - Returns rawDelta() divided by the number of substeps for this frame. It's also capped to a maximum of `TICK_TIME * maxSubsteps()` (so multiplying movement distances by delta() won't result in insane distances covered in odd cases where the physics engine tries to simulate 1 full second with just a few substeps).
- Bdx.substepCount() - The number of substeps for the current game frame.
- Bdx.substepIndex() - The substep index for the current game frame under execution.
- Bdx.minSubsteps() / Bdx.minSubsteps(int) - Gets and sets the minimum number of substeps per frame.
- Bdx.maxSubsteps() / Bdx.maxSubsteps(int) - Gets and sets the maximum number of substeps per frame.

_______

For existing projects to take advantage of unlocked FPS, you'll need to recreate a project to grab the new BdxApp and DesktopLauncher source files (or just add the missing code lines to your project's existing BdxApp and DesktopLauncher files).