### PR TITLE
(#1019) Refining InputMaps Gamepad descriptor search

### DIFF
--- a/src/com/nilunder/bdx/inputs/InputMaps.java
+++ b/src/com/nilunder/bdx/inputs/InputMaps.java
@@ -1,6 +1,7 @@
 package com.nilunder.bdx.inputs;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.utils.Array;
@@ -89,7 +90,7 @@ public class InputMaps extends HashMap<String, InputMaps.Inputs> {
 						return r;
 					}
 				};
-			}else if (d[0].contains("g")){
+			}else if (Pattern.compile("^g[0-9]$").matcher(d[0]).find()){
 				final int gpIndex;
 
 				// GWT doesn't implement Character.getNumericValue(), so do this instead


### PR DESCRIPTION
API change in [customDescriptorsHDU](https://github.com/GoranM/bdx/wiki/API-InputMaps#customDescriptorsHDU)
- The String argument is not expected to be one of the following: `"k"`, `"m"`, `"g"`, `"g0"`, `"g1"`, `"g2"`, ... 