### PR TITLE
exporter-fix: avoid duplication in instantiator

### DIFF
--- a/blender/bdx/exporter.py
+++ b/blender/bdx/exporter.py
@@ -662,7 +662,7 @@ def instantiator(objects):
     shared_names = []
     for o in objects:
         cls_name = get_cls_name(o)
-        if cls_name in name_class:
+        if cls_name in name_class and cls_name not in shared_names:
             shared_names.append(cls_name)
 
     if not shared_names:


### PR DESCRIPTION
With shared custom class names `exporter.instantiator(objects)` generates identical lines. For example, when adding three empties to the default scene and using a custom class `Empty.java` for each empty, `iScene.java` will contain identical lines for those empties:
```java
		if (gobj.get("class").asString().equals("Empty"))
			return new com.raco.test.Empty();
		if (gobj.get("class").asString().equals("Sacky"))
			return new com.raco.test.Sacky();
		if (gobj.get("class").asString().equals("Empty"))
			return new com.raco.test.Empty();
		if (gobj.get("class").asString().equals("Empty"))
			return new com.raco.test.Empty();
```