### PR TITLE
(#1019) Edit imaps descripter directly

### DIFF
--- a/src/com/nilunder/bdx/inputs/InputMaps.java
+++ b/src/com/nilunder/bdx/inputs/InputMaps.java
@@ -41,10 +41,10 @@ public class InputMaps extends HashMap<String, InputMaps.Inputs> {
 
 			final String[] d = descriptor.split(":");
 
+			if (d[0].equals("g")){  // the gamepad descriptor requires an index
+				d[0] += "0";
+			}
 			parsedDescriptor = d;
-
-			if (d[0].contains("g") && d[0].length() == 1)  // There's not a gamepad id number, so add in "0" for the first
-				parsedDescriptor = new String[]{d[0] + "0", d[1]};
 
 			if (d[0].equals("k")){
 				hdu[0] = new FnBool(){
@@ -94,7 +94,7 @@ public class InputMaps extends HashMap<String, InputMaps.Inputs> {
 				final int gpIndex;
 
 				// GWT doesn't implement Character.getNumericValue(), so do this instead
-				gpIndex = Integer.parseInt("" + parsedDescriptor[0].charAt(1), 36);
+				gpIndex = Integer.parseInt("" + d[0].charAt(1), 36);
 
 				hdu[0] = new FnBool(){
 					public boolean eval(){


### PR DESCRIPTION
I searched the code and api to be sure that the public "parsedDescriptor" field is used nowhere, but if for some reason it was public, @SolarLune, please let me know. It seems that there was no reason to add it.

I apologize for not noticing before. Due to the gravity of this bug, if this is merged, could you draft a new release, @GoranM ?